### PR TITLE
feat: theme-declared page metadata + S3 cold-read fix

### DIFF
--- a/lib/ledger/content/page.ex
+++ b/lib/ledger/content/page.ex
@@ -8,21 +8,44 @@ defmodule Ledger.Content.Page do
     field :body, :string, default: ""
     field :format, :string, default: "markdown"
     field :published, :boolean, default: false
+    field :metadata, :map, default: %{}
     belongs_to :site, Ledger.Sites.Site
     timestamps(type: :utc_datetime)
   end
 
   def changeset(page, attrs) do
     page
-    |> cast(attrs, [:title, :slug, :body, :format, :published, :site_id])
+    |> cast(attrs, [:title, :slug, :body, :format, :published, :metadata, :site_id])
     |> validate_required([:title, :site_id])
     |> validate_inclusion(:format, ~w(markdown html blog))
     |> ensure_slug()
     |> validate_format(:slug, ~r/^[a-z0-9]([a-z0-9-]{0,80}[a-z0-9])?$/,
       message: "lowercase letters, numbers, hyphens"
     )
+    |> normalize_metadata()
     |> unique_constraint([:site_id, :slug], name: :pages_site_id_slug_index)
     |> assoc_constraint(:site)
+  end
+
+  # Form posts arrive as `metadata[<key>] => "..."`. Strip empty-string
+  # values so the renderer falls back to the manifest default instead of
+  # storing an empty override. Booleans come in as "true" / "on" / absent;
+  # absent means "false" (HTML checkbox semantics) — keep them coerced as
+  # strings here and let `Manifest.effective_metadata/2` coerce to the
+  # declared type at render time. Unknown keys are preserved.
+  defp normalize_metadata(changeset) do
+    case get_change(changeset, :metadata) do
+      m when is_map(m) ->
+        cleaned =
+          m
+          |> Enum.reject(fn {_, v} -> v == "" or is_nil(v) end)
+          |> Map.new()
+
+        put_change(changeset, :metadata, cleaned)
+
+      _ ->
+        changeset
+    end
   end
 
   defp ensure_slug(changeset) do

--- a/lib/ledger/themes/loader.ex
+++ b/lib/ledger/themes/loader.ex
@@ -52,16 +52,22 @@ defmodule Ledger.Themes.Loader do
   Read a theme from its source root without consulting the cache.
   Used by the seed task to compute manifest+version before deciding
   whether to upsert, and by `fetch!/1` on cache miss.
+
+  Built-ins are read from `priv/themes/<slug>/` via the filesystem.
+  Uploaded themes are read through `Ledger.Storage.read/1`, which routes
+  to whichever adapter is configured (local disk or S3). This is the
+  cold-cache path — once an entry lands in `:persistent_term`, the
+  Renderer never touches storage again.
   """
   @spec read_from_source!(Theme.t()) :: entry()
   def read_from_source!(%Theme{source: "built_in", storage_path: path} = theme) do
-    root = Path.join([:code.priv_dir(:ledger) |> to_string(), path])
-    read_root!(theme, root, asset_base_for_built_in(path))
+    reader = priv_reader(path)
+    read_with(theme, reader, asset_base_for(path))
   end
 
   def read_from_source!(%Theme{source: "uploaded", storage_path: path} = theme) do
-    root = Path.join(Ledger.Storage.Local.root_path(), path)
-    read_root!(theme, root, asset_base_for_uploaded(path))
+    reader = storage_reader(path)
+    read_with(theme, reader, asset_base_for(path))
   end
 
   @doc """
@@ -76,21 +82,37 @@ defmodule Ledger.Themes.Loader do
         }
   def read_built_in_source!(slug) when is_binary(slug) do
     storage_path = Path.join("themes", slug)
-    root = Path.join([:code.priv_dir(:ledger) |> to_string(), storage_path])
-
-    manifest = read_manifest!(root)
-    templates = read_templates!(root)
-    css = read_css!(root)
+    reader = priv_reader(storage_path)
 
     %{
-      manifest: manifest,
-      templates: templates,
-      css: css,
+      manifest: read_manifest!(reader),
+      templates: read_templates!(reader),
+      css: read_css!(reader),
       storage_path: storage_path
     }
   end
 
   # ---- internal ----
+
+  # A reader is `(relative_path :: String.t()) -> {:ok, binary} | {:error, term}`.
+  # We pass it around so file-reading code can be source-agnostic — priv
+  # disk for built-ins, Storage adapter (local or S3) for uploads.
+
+  defp priv_reader(storage_path) do
+    root = Path.join([:code.priv_dir(:ledger) |> to_string(), storage_path])
+
+    fn rel ->
+      case File.read(Path.join(root, rel)) do
+        {:ok, body} -> {:ok, body}
+        {:error, :enoent} -> {:error, :not_found}
+        {:error, _} = err -> err
+      end
+    end
+  end
+
+  defp storage_reader(storage_path) do
+    fn rel -> Ledger.Storage.read(Path.join(storage_path, rel)) end
+  end
 
   defp load_and_cache!(theme) do
     entry = read_from_source!(theme)
@@ -98,66 +120,52 @@ defmodule Ledger.Themes.Loader do
     entry
   end
 
-  defp read_root!(%Theme{} = theme, root, asset_base) do
-    manifest = read_manifest!(root)
-    templates = read_templates!(root)
-    css = read_css!(root)
-
+  defp read_with(%Theme{} = theme, reader, asset_base) do
     %{
       theme: theme,
-      manifest: manifest,
-      templates: templates,
-      css: css,
+      manifest: read_manifest!(reader),
+      templates: read_templates!(reader),
+      css: read_css!(reader),
       asset_base: asset_base
     }
   end
 
-  defp read_manifest!(root) do
-    path = Path.join(root, "manifest.json")
-
-    case File.read(path) do
+  defp read_manifest!(reader) do
+    case reader.("manifest.json") do
       {:ok, body} ->
         case Manifest.parse(body) do
           {:ok, manifest} -> manifest
-          {:error, errors} -> raise "invalid manifest at #{path}: #{Enum.join(errors, ", ")}"
+          {:error, errors} -> raise "invalid manifest: #{Enum.join(errors, ", ")}"
         end
 
       {:error, reason} ->
-        raise "could not read manifest at #{path}: #{:file.format_error(reason)}"
+        raise "could not read manifest.json: #{inspect(reason)}"
     end
   end
 
-  defp read_templates!(root) do
+  defp read_templates!(reader) do
     Map.new(@template_names, fn name ->
-      path = Path.join([root, "templates", name <> ".liquid"])
+      rel = "templates/" <> name <> ".liquid"
 
-      case File.read(path) do
+      case reader.(rel) do
         {:ok, body} ->
           case Sandbox.parse(body) do
             {:ok, template} -> {String.to_atom(name), template}
-            {:error, err} -> raise "could not parse #{path}: #{inspect(err)}"
+            {:error, err} -> raise "could not parse #{rel}: #{inspect(err)}"
           end
 
         {:error, reason} ->
-          raise "missing template #{path}: #{:file.format_error(reason)}"
+          raise "missing template #{rel}: #{inspect(reason)}"
       end
     end)
   end
 
-  defp read_css!(root) do
-    path = Path.join(root, "theme.css")
-
-    case File.read(path) do
+  defp read_css!(reader) do
+    case reader.("theme.css") do
       {:ok, body} -> body
-      {:error, reason} -> raise "missing theme.css at #{path}: #{:file.format_error(reason)}"
+      {:error, reason} -> raise "missing theme.css: #{inspect(reason)}"
     end
   end
 
-  # Built-in assets are served from priv via the same `/uploads/themes/...`
-  # mount used for uploaded themes. We'll wire the priv mount in Phase 4
-  # alongside the upload pipeline. For now, return the placeholder path —
-  # nothing references it in the v1 built-in templates.
-  defp asset_base_for_built_in(storage_path), do: "/uploads/" <> storage_path <> "/assets"
-
-  defp asset_base_for_uploaded(storage_path), do: "/uploads/" <> storage_path <> "/assets"
+  defp asset_base_for(storage_path), do: "/uploads/" <> storage_path <> "/assets"
 end

--- a/lib/ledger/themes/manifest.ex
+++ b/lib/ledger/themes/manifest.ex
@@ -25,12 +25,21 @@ defmodule Ledger.Themes.Manifest do
   """
 
   @valid_token_types ~w(color string length number)
+  @valid_metadata_types ~w(string text boolean color url select number)
 
   @slug_re ~r/^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$/
   @token_key_re ~r/^[a-z][a-z0-9_]*$/
 
   @enforce_keys [:name, :slug, :version, :tokens]
-  defstruct [:name, :slug, :version, :author, :description, tokens: []]
+  defstruct [
+    :name,
+    :slug,
+    :version,
+    :author,
+    :description,
+    tokens: [],
+    metadata: []
+  ]
 
   @type token :: %{
           key: String.t(),
@@ -39,13 +48,23 @@ defmodule Ledger.Themes.Manifest do
           default: String.t()
         }
 
+  @type metadata_field :: %{
+          key: String.t(),
+          label: String.t(),
+          type: String.t(),
+          default: term(),
+          description: String.t() | nil,
+          options: [String.t()] | nil
+        }
+
   @type t :: %__MODULE__{
           name: String.t(),
           slug: String.t(),
           version: String.t(),
           author: String.t() | nil,
           description: String.t() | nil,
-          tokens: [token()]
+          tokens: [token()],
+          metadata: [metadata_field()]
         }
 
   @doc """
@@ -76,6 +95,7 @@ defmodule Ledger.Themes.Manifest do
       |> optional_string(map, "author", 0, 100)
       |> optional_string(map, "description", 0, 500)
       |> validate_tokens(map)
+      |> validate_metadata(map)
 
     case errors do
       [] ->
@@ -85,7 +105,8 @@ defmodule Ledger.Themes.Manifest do
           version: map["version"],
           author: map["author"],
           description: map["description"],
-          tokens: normalize_tokens(Map.get(map, "tokens", []))
+          tokens: normalize_tokens(Map.get(map, "tokens", [])),
+          metadata: normalize_metadata(Map.get(map, "metadata", []))
         }
 
         {:ok, manifest}
@@ -113,6 +134,54 @@ defmodule Ledger.Themes.Manifest do
       Map.put(acc, key, value)
     end)
   end
+
+  @doc """
+  Return the merge of manifest metadata defaults with per-page overrides.
+
+  Differences from `effective_tokens/2`:
+
+    * Unknown override keys are **preserved** — the page may have been
+      authored under a different theme. Tokens disappear silently because
+      they're inert without a matching CSS variable; metadata is meant to
+      survive theme switches so the user doesn't lose data.
+    * Values are coerced to the declared type at the boundary so the
+      template sees a typed value (boolean true vs. "true", etc).
+  """
+  @spec effective_metadata(t(), map()) :: %{String.t() => term()}
+  def effective_metadata(%__MODULE__{metadata: fields}, overrides) when is_map(overrides) do
+    defaults =
+      Enum.reduce(fields, %{}, fn %{key: key, type: type, default: default}, acc ->
+        Map.put(acc, key, coerce_metadata_value(type, default))
+      end)
+
+    # Apply overrides for declared fields (with coercion). Unknown keys are
+    # passed through verbatim so theme-specific data is preserved across
+    # theme changes.
+    field_keys = Enum.map(fields, & &1.key) |> MapSet.new()
+
+    Enum.reduce(overrides, defaults, fn {k, v}, acc ->
+      if MapSet.member?(field_keys, k) do
+        type = Enum.find_value(fields, fn f -> if f.key == k, do: f.type end)
+        Map.put(acc, k, coerce_metadata_value(type, v))
+      else
+        Map.put(acc, k, v)
+      end
+    end)
+  end
+
+  defp coerce_metadata_value("boolean", v) when is_boolean(v), do: v
+  defp coerce_metadata_value("boolean", v) when v in ["true", "on", "1", 1], do: true
+  defp coerce_metadata_value("boolean", _), do: false
+  defp coerce_metadata_value("number", v) when is_number(v), do: v
+
+  defp coerce_metadata_value("number", v) when is_binary(v) do
+    case Float.parse(v) do
+      {n, ""} -> if n == trunc(n), do: trunc(n), else: n
+      _ -> v
+    end
+  end
+
+  defp coerce_metadata_value(_type, v), do: v
 
   # ---- internal validators ----
 
@@ -228,6 +297,86 @@ defmodule Ledger.Themes.Manifest do
         label: tok["label"],
         type: tok["type"],
         default: tok["default"]
+      }
+    end)
+  end
+
+  defp validate_metadata(errors, map) do
+    case Map.get(map, "metadata", []) do
+      list when is_list(list) ->
+        list
+        |> Enum.with_index()
+        |> Enum.reduce(errors, fn {field, idx}, acc ->
+          validate_metadata_field(acc, field, idx)
+        end)
+
+      _ ->
+        ["metadata: must be a list" | errors]
+    end
+  end
+
+  defp validate_metadata_field(errors, field, idx) when is_map(field) do
+    prefix = "metadata[#{idx}]"
+
+    errors =
+      case Map.get(field, "key") do
+        k when is_binary(k) ->
+          if Regex.match?(@token_key_re, k) do
+            errors
+          else
+            ["#{prefix}.key: must match #{inspect(@token_key_re.source)}" | errors]
+          end
+
+        _ ->
+          ["#{prefix}.key: is required and must be a string" | errors]
+      end
+
+    errors =
+      case Map.get(field, "label") do
+        l when is_binary(l) and l != "" -> errors
+        _ -> ["#{prefix}.label: is required and must be a non-empty string" | errors]
+      end
+
+    type = Map.get(field, "type")
+
+    errors =
+      cond do
+        type not in @valid_metadata_types ->
+          [
+            "#{prefix}.type: must be one of #{Enum.join(@valid_metadata_types, ", ")}"
+            | errors
+          ]
+
+        type == "select" and not is_list(Map.get(field, "options")) ->
+          ["#{prefix}.options: select fields require a non-empty options list" | errors]
+
+        type == "select" and Map.get(field, "options") == [] ->
+          ["#{prefix}.options: select fields require a non-empty options list" | errors]
+
+        true ->
+          errors
+      end
+
+    # default is required but its allowed shape depends on the type — we
+    # accept anything JSON-serializable and coerce at read time.
+    case Map.has_key?(field, "default") do
+      true -> errors
+      false -> ["#{prefix}.default: is required" | errors]
+    end
+  end
+
+  defp validate_metadata_field(errors, _, idx),
+    do: ["metadata[#{idx}]: must be an object" | errors]
+
+  defp normalize_metadata(list) when is_list(list) do
+    Enum.map(list, fn field ->
+      %{
+        key: field["key"],
+        label: field["label"],
+        type: field["type"],
+        default: field["default"],
+        description: field["description"],
+        options: field["options"]
       }
     end)
   end

--- a/lib/ledger/themes/presenter.ex
+++ b/lib/ledger/themes/presenter.ex
@@ -42,7 +42,11 @@ defmodule Ledger.Themes.Presenter do
       "title" => pg.title,
       "slug" => pg.slug,
       "format" => pg.format,
-      "url" => "/" <> pg.slug
+      "url" => "/" <> pg.slug,
+      # Raw override map. The Renderer merges manifest defaults on top of
+      # this before exposing it to templates, so theme authors can read
+      # `page.metadata.<key>` and always get the effective value.
+      "metadata" => pg.metadata || %{}
     }
   end
 

--- a/lib/ledger/themes/renderer.ex
+++ b/lib/ledger/themes/renderer.ex
@@ -92,7 +92,11 @@ defmodule Ledger.Themes.Renderer do
     inner_template = Map.fetch!(entry.templates, target)
     layout_template = Map.fetch!(entry.templates, :layout)
 
-    inner_context = Map.merge(base_context, target_assigns)
+    inner_context =
+      base_context
+      |> Map.merge(target_assigns)
+      |> compose_page_metadata(entry.manifest)
+
     {:ok, inner_iodata, _errs} = Sandbox.render(inner_template, inner_context)
     inner_html = IO.iodata_to_binary(inner_iodata)
 
@@ -101,6 +105,19 @@ defmodule Ledger.Themes.Renderer do
 
     IO.iodata_to_binary(layout_iodata)
   end
+
+  # When this render target carries a `page`, replace its raw `metadata`
+  # override map with the effective merge against the manifest schema, so
+  # templates can read `page.metadata.<key>` and always see a value (the
+  # manifest default if the page has no override). Unknown keys on the
+  # page survive — theme-switch resilience comes from the manifest layer.
+  defp compose_page_metadata(%{"page" => %{} = page} = context, manifest) do
+    raw = Map.get(page, "metadata", %{})
+    effective = Manifest.effective_metadata(manifest, raw)
+    Map.put(context, "page", Map.put(page, "metadata", effective))
+  end
+
+  defp compose_page_metadata(context, _manifest), do: context
 
   defp resolve_theme(%Ledger.Sites.Site{theme_id: id}) when is_integer(id) do
     Themes.get_theme!(id)

--- a/lib/ledger_web/live/admin/page_form.ex
+++ b/lib/ledger_web/live/admin/page_form.ex
@@ -3,7 +3,7 @@ defmodule LedgerWeb.AdminLive.PageForm do
   on_mount {LedgerWeb.AdminLive.Hooks, :load_site}
 
   import LedgerWeb.AdminLive.Components
-  alias Ledger.Content
+  alias Ledger.{Content, Themes}
   alias Ledger.Content.Page
 
   @impl true
@@ -18,6 +18,8 @@ defmodule LedgerWeb.AdminLive.PageForm do
           {page, page_to_draft(page), "Edit: #{page.title}", 3}
       end
 
+    metadata_fields = metadata_fields_for_site(socket.assigns.site)
+
     {:ok,
      socket
      |> assign(
@@ -27,10 +29,44 @@ defmodule LedgerWeb.AdminLive.PageForm do
        page_title: page_title,
        preview_html: render_preview(draft),
        slug_touched: page != nil,
-       show_errors: false
+       show_errors: false,
+       metadata_fields: metadata_fields
      )
      |> assign_changeset(draft)}
   end
+
+  # Pull the metadata schema off the site's current theme. Returns a list
+  # of `%{key, label, type, default, description, options}` maps, or [] if
+  # the theme declares none.
+  defp metadata_fields_for_site(%Ledger.Sites.Site{theme_id: id}) when is_integer(id) do
+    case Themes.get_theme(id) do
+      nil -> []
+      theme -> extract_metadata_fields(theme.manifest)
+    end
+  end
+
+  defp metadata_fields_for_site(_), do: []
+
+  defp extract_metadata_fields(%{} = manifest) do
+    list = Map.get(manifest, "metadata", Map.get(manifest, :metadata, []))
+
+    if is_list(list) do
+      Enum.map(list, fn f ->
+        %{
+          key: f["key"] || f[:key],
+          label: f["label"] || f[:label],
+          type: f["type"] || f[:type],
+          default: f["default"] || f[:default],
+          description: f["description"] || f[:description],
+          options: f["options"] || f[:options] || []
+        }
+      end)
+    else
+      []
+    end
+  end
+
+  defp extract_metadata_fields(_), do: []
 
   @impl true
   def handle_event("choose_format", %{"format" => fmt}, socket)
@@ -166,8 +202,18 @@ defmodule LedgerWeb.AdminLive.PageForm do
       "slug" => page.slug,
       "format" => page.format,
       "body" => page.body,
-      "published" => to_string(page.published)
+      "published" => to_string(page.published),
+      "metadata" => page.metadata || %{}
     }
+  end
+
+  # The metadata input for the given field. The field's key lives at
+  # `page[metadata][<key>]` so it gets cast into the jsonb column.
+  defp metadata_value(draft, key) do
+    case Map.get(draft, "metadata") do
+      %{} = m -> Map.get(m, key) || Map.get(m, to_string(key)) || ""
+      _ -> ""
+    end
   end
 
   defp build_changeset(socket, attrs) do
@@ -234,11 +280,13 @@ defmodule LedgerWeb.AdminLive.PageForm do
             <.content_step
               form={@form}
               changeset={@changeset}
+              draft={@draft}
               format={@draft["format"]}
               preview_html={@preview_html}
               editing={@page != nil}
               site_slug={@site.slug}
               show_errors={@show_errors}
+              metadata_fields={@metadata_fields}
             />
         <% end %>
       </div>
@@ -327,11 +375,13 @@ defmodule LedgerWeb.AdminLive.PageForm do
 
   attr :form, :map, required: true
   attr :changeset, :map, required: true
+  attr :draft, :map, required: true
   attr :format, :string, required: true
   attr :preview_html, :string, required: true
   attr :editing, :boolean, default: false
   attr :site_slug, :string, required: true
   attr :show_errors, :boolean, default: false
+  attr :metadata_fields, :list, default: []
 
   defp content_step(assigns) do
     ~H"""
@@ -353,6 +403,8 @@ defmodule LedgerWeb.AdminLive.PageForm do
       <% else %>
         <.body_editor form={@form} format={@format} preview_html={@preview_html} />
       <% end %>
+
+      <.metadata_section :if={@metadata_fields != []} fields={@metadata_fields} draft={@draft} />
     </form>
 
     <div class="wizard-footer">
@@ -446,6 +498,105 @@ defmodule LedgerWeb.AdminLive.PageForm do
 
   defp format_label("html"), do: "HTML"
   defp format_label(_), do: "Markdown"
+
+  attr :fields, :list, required: true
+  attr :draft, :map, required: true
+
+  defp metadata_section(assigns) do
+    ~H"""
+    <section class="settings-section">
+      <header class="settings-section-head">
+        <h2>Page settings</h2>
+        <p>Theme-specific overrides for this page. Blank fields fall back to the theme default.</p>
+      </header>
+
+      <div class="settings-fields">
+        <.metadata_field :for={f <- @fields} field={f} value={metadata_value(@draft, f.key)} />
+      </div>
+    </section>
+    """
+  end
+
+  attr :field, :map, required: true
+  attr :value, :any, required: true
+
+  defp metadata_field(%{field: %{type: "boolean"}} = assigns) do
+    assigns = assign(assigns, :checked?, truthy?(assigns.value, assigns.field.default))
+
+    ~H"""
+    <label class="checkbox-label">
+      <input type="hidden" name={"page[metadata][" <> @field.key <> "]"} value="false" />
+      <input
+        type="checkbox"
+        name={"page[metadata][" <> @field.key <> "]"}
+        value="true"
+        checked={@checked?}
+      />
+      <span>{@field.label}</span>
+      <small :if={@field.description}>{@field.description}</small>
+    </label>
+    """
+  end
+
+  defp metadata_field(%{field: %{type: "select"}} = assigns) do
+    ~H"""
+    <label>
+      {@field.label}
+      <select name={"page[metadata][" <> @field.key <> "]"}>
+        <option
+          :for={opt <- @field.options}
+          value={opt}
+          selected={to_string(opt) == to_string((@value == "" && @field.default) || @value)}
+        >
+          {opt}
+        </option>
+      </select>
+      <small :if={@field.description}>{@field.description}</small>
+    </label>
+    """
+  end
+
+  defp metadata_field(%{field: %{type: "text"}} = assigns) do
+    ~H"""
+    <label>
+      {@field.label}
+      <textarea
+        name={"page[metadata][" <> @field.key <> "]"}
+        rows="3"
+        placeholder={to_string(@field.default || "")}
+      >{@value}</textarea>
+      <small :if={@field.description}>{@field.description}</small>
+    </label>
+    """
+  end
+
+  defp metadata_field(assigns) do
+    ~H"""
+    <label>
+      {@field.label}
+      <input
+        type={metadata_input_type(@field.type)}
+        name={"page[metadata][" <> @field.key <> "]"}
+        value={@value}
+        placeholder={to_string(@field.default || "")}
+      />
+      <small :if={@field.description}>{@field.description}</small>
+    </label>
+    """
+  end
+
+  defp metadata_input_type("color"), do: "color"
+  defp metadata_input_type("number"), do: "number"
+  defp metadata_input_type("url"), do: "url"
+  defp metadata_input_type(_), do: "text"
+
+  defp truthy?(value, default) do
+    case value do
+      v when v in [true, "true", "on", "1", 1] -> true
+      v when v in [false, "false", "0", 0, nil, ""] -> false
+      _ -> truthy?(default, false)
+    end
+  end
 
   defp publish_button_class(true), do: "btn btn-publish-toggle btn-published"
   defp publish_button_class(_), do: "btn btn-publish-toggle btn-draft"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.1.0",
+      version: "1.2.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260515145256_add_metadata_to_pages.exs
+++ b/priv/repo/migrations/20260515145256_add_metadata_to_pages.exs
@@ -1,0 +1,12 @@
+defmodule Ledger.Repo.Migrations.AddMetadataToPages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:pages) do
+      # Theme-scoped per-page metadata. Shape is driven by the active theme's
+      # manifest `metadata` schema; unknown keys are preserved on save so
+      # data survives theme switches.
+      add :metadata, :map, null: false, default: %{}
+    end
+  end
+end

--- a/test/ledger/themes/manifest_test.exs
+++ b/test/ledger/themes/manifest_test.exs
@@ -72,4 +72,99 @@ defmodule Ledger.Themes.ManifestTest do
       refute Map.has_key?(out, "nope")
     end
   end
+
+  describe "metadata schema parsing" do
+    test "accepts all supported field types" do
+      json = """
+      {"name":"X","slug":"x","version":"1.0.0","tokens":[],
+       "metadata":[
+         {"key":"s","label":"S","type":"string","default":""},
+         {"key":"t","label":"T","type":"text","default":""},
+         {"key":"b","label":"B","type":"boolean","default":false},
+         {"key":"c","label":"C","type":"color","default":"#fff"},
+         {"key":"u","label":"U","type":"url","default":""},
+         {"key":"n","label":"N","type":"number","default":0},
+         {"key":"sel","label":"Sel","type":"select","options":["a","b"],"default":"a"}
+       ]}
+      """
+
+      assert {:ok, %Manifest{metadata: fields}} = Manifest.parse(json)
+      assert length(fields) == 7
+    end
+
+    test "select fields require a non-empty options list" do
+      json = ~s({"name":"X","slug":"x","version":"1.0.0","tokens":[],
+                 "metadata":[{"key":"sel","label":"S","type":"select","default":"a"}]})
+
+      assert {:error, errs} = Manifest.parse(json)
+      assert Enum.any?(errs, &String.contains?(&1, "options"))
+    end
+
+    test "default is required for every field" do
+      json = ~s({"name":"X","slug":"x","version":"1.0.0","tokens":[],
+                 "metadata":[{"key":"k","label":"K","type":"string"}]})
+
+      assert {:error, errs} = Manifest.parse(json)
+      assert Enum.any?(errs, &String.contains?(&1, "default"))
+    end
+
+    test "unknown type is rejected" do
+      json = ~s({"name":"X","slug":"x","version":"1.0.0","tokens":[],
+                 "metadata":[{"key":"k","label":"K","type":"weird","default":""}]})
+
+      assert {:error, errs} = Manifest.parse(json)
+      assert Enum.any?(errs, &String.contains?(&1, "type:"))
+    end
+
+    test "missing metadata key is fine (defaults to empty list)" do
+      json = ~s({"name":"X","slug":"x","version":"1.0.0","tokens":[]})
+      assert {:ok, %Manifest{metadata: []}} = Manifest.parse(json)
+    end
+  end
+
+  describe "effective_metadata/2" do
+    setup do
+      {:ok, m} =
+        Manifest.parse(~s({
+          "name":"X","slug":"x","version":"1.0.0","tokens":[],
+          "metadata":[
+            {"key":"layout","label":"L","type":"select","options":["a","b"],"default":"a"},
+            {"key":"hero","label":"H","type":"url","default":""},
+            {"key":"hide","label":"D","type":"boolean","default":false},
+            {"key":"count","label":"C","type":"number","default":0}
+          ]
+        }))
+
+      {:ok, manifest: m}
+    end
+
+    test "falls back to declared defaults", %{manifest: m} do
+      assert %{
+               "layout" => "a",
+               "hero" => "",
+               "hide" => false,
+               "count" => 0
+             } = Manifest.effective_metadata(m, %{})
+    end
+
+    test "overrides win", %{manifest: m} do
+      assert %{"layout" => "b", "hero" => "/x.jpg"} =
+               Manifest.effective_metadata(m, %{"layout" => "b", "hero" => "/x.jpg"})
+    end
+
+    test "booleans coerce from form strings", %{manifest: m} do
+      assert %{"hide" => true} = Manifest.effective_metadata(m, %{"hide" => "true"})
+      assert %{"hide" => false} = Manifest.effective_metadata(m, %{"hide" => "false"})
+    end
+
+    test "numbers coerce from form strings", %{manifest: m} do
+      assert %{"count" => 42} = Manifest.effective_metadata(m, %{"count" => "42"})
+      assert %{"count" => 3.5} = Manifest.effective_metadata(m, %{"count" => "3.5"})
+    end
+
+    test "unknown override keys are preserved (theme-switch resilience)", %{manifest: m} do
+      out = Manifest.effective_metadata(m, %{"from_old_theme" => "still here"})
+      assert out["from_old_theme"] == "still here"
+    end
+  end
 end

--- a/test/ledger/themes/renderer_test.exs
+++ b/test/ledger/themes/renderer_test.exs
@@ -144,4 +144,119 @@ defmodule Ledger.Themes.RendererTest do
       assert out =~ "--accent: #ff0000"
     end
   end
+
+  describe "page metadata" do
+    setup %{user: user, site: site} do
+      # Install a tiny theme that declares a metadata schema and uses it
+      # in page.liquid. Stripped down to just what we need to test.
+      slug = "metatest#{System.unique_integer([:positive])}"
+      zip_path = build_metadata_theme_zip(slug)
+
+      {:ok, theme} = Ledger.Themes.Package.install(zip_path, user.id)
+      File.rm(zip_path)
+      {:ok, site} = Sites.update_settings(site, %{"theme_id" => theme.id})
+      site = Sites.get_site!(site.id)
+
+      {:ok, theme: theme, site: site}
+    end
+
+    test "manifest defaults reach the template", %{site: site} do
+      [page | _] = Content.list_published_pages(site.id)
+      pages = Content.list_published_pages(site.id)
+      body_html = Content.render_body(page.body, page.format)
+
+      out =
+        Renderer.render_page(%{
+          site: site,
+          page: page,
+          body_html: body_html,
+          pages: pages
+        })
+
+      assert out =~ ~s(data-layout="contained")
+    end
+
+    test "per-page overrides win over manifest defaults", %{site: site} do
+      [page | _] = Content.list_published_pages(site.id)
+      {:ok, page} = Content.update_page(page, %{"metadata" => %{"layout" => "wide"}})
+
+      pages = Content.list_published_pages(site.id)
+      body_html = Content.render_body(page.body, page.format)
+
+      out =
+        Renderer.render_page(%{
+          site: site,
+          page: page,
+          body_html: body_html,
+          pages: pages
+        })
+
+      assert out =~ ~s(data-layout="wide")
+    end
+
+    test "empty-string metadata override falls back to default", %{site: site} do
+      [page | _] = Content.list_published_pages(site.id)
+      # Empty values are stripped by the Page changeset's normalize_metadata.
+      {:ok, page} = Content.update_page(page, %{"metadata" => %{"layout" => ""}})
+      assert page.metadata == %{}
+
+      pages = Content.list_published_pages(site.id)
+      body_html = Content.render_body(page.body, page.format)
+
+      out =
+        Renderer.render_page(%{
+          site: site,
+          page: page,
+          body_html: body_html,
+          pages: pages
+        })
+
+      assert out =~ ~s(data-layout="contained")
+    end
+
+    test "unknown keys (from a previous theme) are preserved on save", %{site: site} do
+      [page | _] = Content.list_published_pages(site.id)
+
+      {:ok, page} =
+        Content.update_page(page, %{"metadata" => %{"from_old_theme" => "still here"}})
+
+      assert page.metadata["from_old_theme"] == "still here"
+    end
+  end
+
+  # Helper: write a minimal zipped theme that surfaces page.metadata.layout
+  # via a data attribute in the rendered HTML.
+  defp build_metadata_theme_zip(slug) do
+    files = %{
+      "manifest.json" =>
+        Jason.encode!(%{
+          "name" => "Meta " <> slug,
+          "slug" => slug,
+          "version" => "1.0.0",
+          "tokens" => [],
+          "metadata" => [
+            %{
+              "key" => "layout",
+              "label" => "Layout",
+              "type" => "select",
+              "options" => ["contained", "wide"],
+              "default" => "contained"
+            }
+          ]
+        }),
+      "templates/layout.liquid" => "<html><head></head><body>{{ content }}</body></html>",
+      "templates/index.liquid" => "<h1>{{ site.name | escape }}</h1>",
+      "templates/post.liquid" => "<article>{{ body_html }}</article>",
+      "templates/page.liquid" =>
+        "<article data-layout=\"{{ page.metadata.layout }}\">{{ body_html }}</article>",
+      "templates/blog.liquid" => "<h1>{{ page.title | escape }}</h1>",
+      "templates/not_found.liquid" => "<h1>Not found</h1>",
+      "theme.css" => "body { background: white; }"
+    }
+
+    tmp = Path.join(System.tmp_dir!(), "metatest-#{System.unique_integer([:positive])}.zip")
+    entries = Enum.map(files, fn {n, b} -> {String.to_charlist(n), b} end)
+    {:ok, _} = :zip.create(String.to_charlist(tmp), entries)
+    tmp
+  end
 end


### PR DESCRIPTION
Themes can now declare a per-page metadata schema in `manifest.json` alongside their tokens. The page admin form renders a typed input per declared field; values flow through the renderer as `page.metadata.<key>` so theme authors can branch on them (full-width layouts, hero images, per-page accents, etc).

- Manifest: validate `metadata` array; supported types string / text / boolean / color / url / select / number. `effective_metadata/2` mirrors `effective_tokens/2` but preserves unknown override keys so pages survive theme switches; values coerce to the declared type.
- DB: `pages.metadata` jsonb default {}. Empty-string overrides stripped on save so we fall back to manifest defaults.
- Presenter / Renderer: project raw overrides on the page, merge with manifest defaults at render time.
- PageForm: "Page settings" section in the content step, rendered from the active theme's manifest. Checkbox / select / color / number / text inputs per field type.

Also fixes a real-world bug: the loader's cold-cache path for uploaded themes was reading directly from `priv/uploads/...`, which worked locally but broke on S3 deploys after a VM restart (the only path that ever populated the cache for uploads was Package.warm_cache during install). The loader now goes through `Ledger.Storage.read/1` for uploaded themes, so the adapter (local disk or S3) handles the actual fetch.