### PR TITLE
feat: dedicated wizard step for page metadata

### DIFF
--- a/lib/ledger_web/live/admin/page_form.ex
+++ b/lib/ledger_web/live/admin/page_form.ex
@@ -15,10 +15,14 @@ defmodule LedgerWeb.AdminLive.PageForm do
 
         :edit ->
           page = Content.get_page!(socket.assigns.site.id, params["id"])
-          {page, page_to_draft(page), "Edit: #{page.title}", 3}
+          # Existing pages open directly on the content step (4). Reaching
+          # the settings step (3) requires the Back button — it's an edit
+          # affordance, not the primary path.
+          {page, page_to_draft(page), "Edit: #{page.title}", 4}
       end
 
     metadata_fields = metadata_fields_for_site(socket.assigns.site)
+    has_metadata? = metadata_fields != []
 
     {:ok,
      socket
@@ -30,7 +34,8 @@ defmodule LedgerWeb.AdminLive.PageForm do
        preview_html: render_preview(draft),
        slug_touched: page != nil,
        show_errors: false,
-       metadata_fields: metadata_fields
+       metadata_fields: metadata_fields,
+       has_metadata?: has_metadata?
      )
      |> assign_changeset(draft)}
   end
@@ -82,11 +87,12 @@ defmodule LedgerWeb.AdminLive.PageForm do
   end
 
   def handle_event("advance", _params, socket) do
-    {:noreply, assign(socket, step: min(socket.assigns.step + 1, 3))}
+    # Only fired from the Format step → Details.
+    {:noreply, assign(socket, step: 2)}
   end
 
   def handle_event("back", _params, socket) do
-    {:noreply, assign(socket, step: max(socket.assigns.step - 1, 1))}
+    {:noreply, assign(socket, step: prev_step(socket))}
   end
 
   def handle_event("next_meta", %{"page" => params}, socket) do
@@ -94,9 +100,13 @@ defmodule LedgerWeb.AdminLive.PageForm do
     changeset = build_changeset(socket, draft)
 
     if Ecto.Changeset.get_field(changeset, :title) not in [nil, ""] do
+      # Skip the settings step entirely when the theme declares no
+      # metadata — we'd render an empty step otherwise.
+      next = if socket.assigns.has_metadata?, do: 3, else: 4
+
       {:noreply,
        socket
-       |> assign(draft: draft, step: 3)
+       |> assign(draft: draft, step: next)
        |> assign_changeset(draft)}
     else
       {:noreply,
@@ -104,6 +114,21 @@ defmodule LedgerWeb.AdminLive.PageForm do
        |> assign(draft: draft, show_errors: true)
        |> assign_changeset(draft, validate: true)}
     end
+  end
+
+  def handle_event("next_settings", %{"page" => params}, socket) do
+    # Merge the metadata sub-map into the draft and advance to Content.
+    draft = Map.merge(socket.assigns.draft, params)
+
+    {:noreply,
+     socket
+     |> assign(draft: draft, step: 4)
+     |> assign_changeset(draft)}
+  end
+
+  def handle_event("next_settings", _params, socket) do
+    # Form submitted with no inputs (all blank). Still advance.
+    {:noreply, assign(socket, step: 4)}
   end
 
   def handle_event("validate", %{"page" => params} = full_params, socket) do
@@ -266,6 +291,7 @@ defmodule LedgerWeb.AdminLive.PageForm do
               format={@draft["format"]}
               editing={@page != nil}
               site_slug={@site.slug}
+              has_metadata={@has_metadata?}
             />
           <% 2 -> %>
             <.meta_step
@@ -275,18 +301,24 @@ defmodule LedgerWeb.AdminLive.PageForm do
               editing={@page != nil}
               site_slug={@site.slug}
               show_errors={@show_errors}
+              has_metadata={@has_metadata?}
             />
           <% 3 -> %>
+            <.settings_step
+              fields={@metadata_fields}
+              draft={@draft}
+              has_metadata={@has_metadata?}
+            />
+          <% 4 -> %>
             <.content_step
               form={@form}
               changeset={@changeset}
-              draft={@draft}
               format={@draft["format"]}
               preview_html={@preview_html}
               editing={@page != nil}
               site_slug={@site.slug}
               show_errors={@show_errors}
-              metadata_fields={@metadata_fields}
+              has_metadata={@has_metadata?}
             />
         <% end %>
       </div>
@@ -295,13 +327,19 @@ defmodule LedgerWeb.AdminLive.PageForm do
   end
 
   attr :step, :integer, default: 1
+  attr :has_metadata, :boolean, default: false
 
   defp stepper(assigns) do
+    assigns = assign(assigns, :entries, Enum.with_index(visible_steps(assigns.has_metadata), 1))
+
     ~H"""
     <ol class="stepper">
-      <li :for={i <- 1..3} class={"step " <> step_class(i, @step)}>
-        <span class="step-num">{i}</span>
-        <span class="step-label">{step_label(i)}</span>
+      <li
+        :for={{{step_num, label}, display_idx} <- @entries}
+        class={"step " <> step_class(step_num, @step)}
+      >
+        <span class="step-num">{display_idx}</span>
+        <span class="step-label">{label}</span>
       </li>
     </ol>
     """
@@ -311,18 +349,29 @@ defmodule LedgerWeb.AdminLive.PageForm do
   defp step_class(i, current) when i == current, do: "step-current"
   defp step_class(_, _), do: "step-future"
 
-  defp step_label(1), do: "Format"
-  defp step_label(2), do: "Details"
-  defp step_label(3), do: "Content"
+  # Returns [{internal_step, label}, ...]. The settings step is omitted
+  # when the active theme declares no metadata fields.
+  defp visible_steps(true),
+    do: [{1, "Format"}, {2, "Details"}, {3, "Page settings"}, {4, "Content"}]
+
+  defp visible_steps(false),
+    do: [{1, "Format"}, {2, "Details"}, {4, "Content"}]
+
+  # Previous step for the Back button. Skips step 3 when there's no
+  # metadata so the user doesn't land on a blank screen.
+  defp prev_step(%{assigns: %{step: 4, has_metadata?: false}}), do: 2
+  defp prev_step(%{assigns: %{step: step}}) when step > 1, do: step - 1
+  defp prev_step(_), do: 1
 
   attr :locked, :boolean, default: false
   attr :format, :string, default: nil
   attr :editing, :boolean, default: false
   attr :site_slug, :string, required: true
+  attr :has_metadata, :boolean, default: false
 
   defp format_step(assigns) do
     ~H"""
-    <.stepper step={1} />
+    <.stepper step={1} has_metadata={@has_metadata} />
 
     <h2 class="wizard-heading">
       {if @editing, do: "Page format", else: "How do you want to write this page?"}
@@ -344,10 +393,11 @@ defmodule LedgerWeb.AdminLive.PageForm do
   attr :editing, :boolean, default: false
   attr :site_slug, :string, required: true
   attr :show_errors, :boolean, default: false
+  attr :has_metadata, :boolean, default: false
 
   defp meta_step(assigns) do
     ~H"""
-    <.stepper step={2} />
+    <.stepper step={2} has_metadata={@has_metadata} />
 
     <form id="meta-form" phx-submit="next_meta" phx-change="validate" class="form">
       <.error_list changeset={@changeset} show={@show_errors} />
@@ -373,19 +423,45 @@ defmodule LedgerWeb.AdminLive.PageForm do
     """
   end
 
+  attr :fields, :list, required: true
+  attr :draft, :map, required: true
+  attr :has_metadata, :boolean, default: true
+
+  defp settings_step(assigns) do
+    ~H"""
+    <.stepper step={3} has_metadata={@has_metadata} />
+
+    <h2 class="wizard-heading">Page settings</h2>
+    <p class="wizard-intro muted">
+      Theme-specific overrides for this page. Blank fields fall back to
+      the theme default.
+    </p>
+
+    <form id="settings-form" phx-submit="next_settings" class="form">
+      <div class="settings-fields">
+        <.metadata_field :for={f <- @fields} field={f} value={metadata_value(@draft, f.key)} />
+      </div>
+    </form>
+
+    <div class="wizard-footer">
+      <button type="button" phx-click="back" class="btn">&larr; Back</button>
+      <button type="submit" form="settings-form" class="btn btn-primary">Continue &rarr;</button>
+    </div>
+    """
+  end
+
   attr :form, :map, required: true
   attr :changeset, :map, required: true
-  attr :draft, :map, required: true
   attr :format, :string, required: true
   attr :preview_html, :string, required: true
   attr :editing, :boolean, default: false
   attr :site_slug, :string, required: true
   attr :show_errors, :boolean, default: false
-  attr :metadata_fields, :list, default: []
+  attr :has_metadata, :boolean, default: false
 
   defp content_step(assigns) do
     ~H"""
-    <.stepper step={3} />
+    <.stepper step={4} has_metadata={@has_metadata} />
 
     <form id="content-form" phx-submit="save" phx-change="validate" class="form post-form">
       <.error_list changeset={@changeset} show={@show_errors} />
@@ -403,8 +479,6 @@ defmodule LedgerWeb.AdminLive.PageForm do
       <% else %>
         <.body_editor form={@form} format={@format} preview_html={@preview_html} />
       <% end %>
-
-      <.metadata_section :if={@metadata_fields != []} fields={@metadata_fields} draft={@draft} />
     </form>
 
     <div class="wizard-footer">
@@ -498,24 +572,6 @@ defmodule LedgerWeb.AdminLive.PageForm do
 
   defp format_label("html"), do: "HTML"
   defp format_label(_), do: "Markdown"
-
-  attr :fields, :list, required: true
-  attr :draft, :map, required: true
-
-  defp metadata_section(assigns) do
-    ~H"""
-    <section class="settings-section">
-      <header class="settings-section-head">
-        <h2>Page settings</h2>
-        <p>Theme-specific overrides for this page. Blank fields fall back to the theme default.</p>
-      </header>
-
-      <div class="settings-fields">
-        <.metadata_field :for={f <- @fields} field={f} value={metadata_value(@draft, f.key)} />
-      </div>
-    </section>
-    """
-  end
 
   attr :field, :map, required: true
   attr :value, :any, required: true

--- a/priv/themes/blank/manifest.json
+++ b/priv/themes/blank/manifest.json
@@ -1,8 +1,25 @@
 {
   "name": "Blank",
   "slug": "blank",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Ledger",
   "description": "Zero chrome — your HTML defines the entire layout.",
-  "tokens": []
+  "tokens": [],
+  "metadata": [
+    {
+      "key": "layout",
+      "label": "Page layout",
+      "type": "select",
+      "options": ["wide", "contained"],
+      "default": "wide",
+      "description": "Switch to 'contained' to wrap this page in a centered column. Default is full-bleed so your HTML controls width."
+    },
+    {
+      "key": "show_navigation",
+      "label": "Show site navigation",
+      "type": "boolean",
+      "default": false,
+      "description": "Add a simple top nav with the site name and published pages. Off by default — Blank is meant to be chrome-free."
+    }
+  ]
 }

--- a/priv/themes/blank/templates/layout.liquid
+++ b/priv/themes/blank/templates/layout.liquid
@@ -11,7 +11,17 @@
     </style>
   </head>
   <body>
-    <main class="content">
+    {% if page.metadata.show_navigation %}
+      <nav class="site-nav">
+        <a class="brand" href="/">{{ site.name | escape }}</a>
+        {% if pages != empty %}
+          <ul>
+            {% for p in pages %}<li><a href="{{ p.url }}">{{ p.title | escape }}</a></li>{% endfor %}
+          </ul>
+        {% endif %}
+      </nav>
+    {% endif %}
+    <main class="content{% if page.metadata.layout == "contained" %} contained{% endif %}">
       {{ content }}
     </main>
   </body>

--- a/priv/themes/blank/theme.css
+++ b/priv/themes/blank/theme.css
@@ -17,6 +17,24 @@ img { max-width: 100%; height: auto; }
 
 /* Content is full-width, zero padding — your HTML defines its own layout */
 .content { width: 100%; }
+/* Opt-in centered column via `metadata.layout = "contained"`. */
+.content.contained { max-width: 720px; margin: 0 auto; padding: 0 1.25rem; }
+
+/* Optional top nav, shown only when `metadata.show_navigation = true`.
+   Kept deliberately spartan to match Blank's no-chrome aesthetic. */
+.site-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1.25rem;
+  border-bottom: 1px solid #eee;
+  font-size: 0.92rem;
+}
+.site-nav .brand { font-weight: 600; color: #111; text-decoration: none; }
+.site-nav ul { list-style: none; display: flex; gap: 1rem; margin: 0; padding: 0; }
+.site-nav a { color: #555; text-decoration: none; }
+.site-nav a:hover { color: #111; }
 
 /* Modest styling for the built-in fallback views (index / post / 404 /
    blog) so they're readable without looking unstyled. HTML and Markdown

--- a/priv/themes/default/manifest.json
+++ b/priv/themes/default/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Default",
   "slug": "default",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Ledger",
   "description": "Minimal, readable, opinionated about typography.",
   "tokens": [
@@ -10,6 +10,16 @@
       "label": "Accent color",
       "type": "color",
       "default": "#0066cc"
+    }
+  ],
+  "metadata": [
+    {
+      "key": "layout",
+      "label": "Page layout",
+      "type": "select",
+      "options": ["contained", "wide"],
+      "default": "contained",
+      "description": "Use 'wide' to escape the max-width container (e.g. for a landing-style homepage)."
     }
   ]
 }

--- a/priv/themes/default/manifest.json
+++ b/priv/themes/default/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Default",
   "slug": "default",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Ledger",
   "description": "Minimal, readable, opinionated about typography.",
   "tokens": [
@@ -20,6 +20,13 @@
       "options": ["contained", "wide"],
       "default": "contained",
       "description": "Use 'wide' to escape the max-width container (e.g. for a landing-style homepage)."
+    },
+    {
+      "key": "show_navigation",
+      "label": "Show site navigation",
+      "type": "boolean",
+      "default": true,
+      "description": "Untick to hide the top nav bar on this page only — useful for splash / landing pages."
     }
   ]
 }

--- a/priv/themes/default/templates/layout.liquid
+++ b/priv/themes/default/templates/layout.liquid
@@ -11,14 +11,16 @@
     </style>
   </head>
   <body>
-    <nav class="site-nav">
-      <a class="brand" href="/">{{ site.name | escape }}</a>
-      {% if pages != empty %}
-        <ul>
-          {% for p in pages %}<li><a href="{{ p.url }}">{{ p.title | escape }}</a></li>{% endfor %}
-        </ul>
-      {% endif %}
-    </nav>
+    {% unless page.metadata.show_navigation == false %}
+      <nav class="site-nav">
+        <a class="brand" href="/">{{ site.name | escape }}</a>
+        {% if pages != empty %}
+          <ul>
+            {% for p in pages %}<li><a href="{{ p.url }}">{{ p.title | escape }}</a></li>{% endfor %}
+          </ul>
+        {% endif %}
+      </nav>
+    {% endunless %}
     <main{% if page.metadata.layout == "wide" %} class="wide"{% endif %}>
       {{ content }}
     </main>

--- a/priv/themes/default/templates/layout.liquid
+++ b/priv/themes/default/templates/layout.liquid
@@ -19,7 +19,7 @@
         </ul>
       {% endif %}
     </nav>
-    <main>
+    <main{% if page.metadata.layout == "wide" %} class="wide"{% endif %}>
       {{ content }}
     </main>
     <footer class="site-footer">

--- a/priv/themes/default/theme.css
+++ b/priv/themes/default/theme.css
@@ -14,6 +14,9 @@ body {
 }
 main { flex: 1; width: 100%; }
 main, .site-nav, .site-footer { max-width: var(--max); margin: 0 auto; padding: 0 1.25rem; width: 100%; }
+/* `wide` page layout escapes the container — set per-page from the
+   editor's "Page settings" via `metadata.layout`. */
+main.wide { max-width: none; padding-left: 0; padding-right: 0; }
 .site-nav { display: flex; align-items: center; justify-content: space-between; padding-top: 2rem; padding-bottom: 1.5rem; border-bottom: 1px solid var(--rule); }
 .site-nav .brand { font-weight: 600; text-decoration: none; color: var(--fg); }
 .site-nav ul { list-style: none; display: flex; gap: 1rem; margin: 0; padding: 0; flex-wrap: wrap; }

--- a/priv/themes/studio/manifest.json
+++ b/priv/themes/studio/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Studio",
   "slug": "studio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Ledger",
   "description": "Editorial / blue accent. Built for long-form reading.",
   "tokens": [
@@ -16,6 +16,23 @@
       "label": "Content width",
       "type": "length",
       "default": "880px"
+    }
+  ],
+  "metadata": [
+    {
+      "key": "layout",
+      "label": "Page layout",
+      "type": "select",
+      "options": ["contained", "wide"],
+      "default": "contained",
+      "description": "Use 'wide' to drop the centered column on this page."
+    },
+    {
+      "key": "show_navigation",
+      "label": "Show site navigation",
+      "type": "boolean",
+      "default": true,
+      "description": "Untick to hide the sticky header on this page only."
     }
   ]
 }

--- a/priv/themes/studio/templates/layout.liquid
+++ b/priv/themes/studio/templates/layout.liquid
@@ -13,22 +13,24 @@
     </style>
   </head>
   <body>
-    <header class="site-header">
-      <div class="container nav">
-        <a class="brand" href="/">
-          <span class="brand-mark">&#9679;</span>
-          <span class="brand-name">{{ site.name | escape }}</span>
-        </a>
-        {% if pages != empty %}
-          <nav class="primary-nav">
-            {% for p in pages %}<a href="{{ p.url }}">{{ p.title | escape }}</a>{% endfor %}
-          </nav>
-        {% endif %}
-      </div>
-    </header>
+    {% unless page.metadata.show_navigation == false %}
+      <header class="site-header">
+        <div class="container nav">
+          <a class="brand" href="/">
+            <span class="brand-mark">&#9679;</span>
+            <span class="brand-name">{{ site.name | escape }}</span>
+          </a>
+          {% if pages != empty %}
+            <nav class="primary-nav">
+              {% for p in pages %}<a href="{{ p.url }}">{{ p.title | escape }}</a>{% endfor %}
+            </nav>
+          {% endif %}
+        </div>
+      </header>
+    {% endunless %}
 
     <main class="content">
-      <div class="container">
+      <div class="container{% if page.metadata.layout == "wide" %} wide{% endif %}">
         {{ content }}
       </div>
     </main>

--- a/priv/themes/studio/theme.css
+++ b/priv/themes/studio/theme.css
@@ -34,6 +34,9 @@ a { color: var(--accent); text-decoration: none; transition: color 0.15s ease; }
 a:hover { color: var(--accent-hover); }
 
 .container { max-width: var(--max-width); margin: 0 auto; padding: 0 1.5rem; width: 100%; }
+/* `wide` page layout escapes the centered column. Header and footer
+   keep their own .container, so only the content area goes wide. */
+.container.wide { max-width: none; padding-left: 0; padding-right: 0; }
 .muted { color: var(--muted); }
 
 /* Header */


### PR DESCRIPTION
The metadata form moves out of the content step into its own step 3 ("Page settings"); the content editor becomes step 4. When the active theme declares no metadata, the step is skipped entirely — the stepper renders 3 dots instead of 4 and the Continue/Back transitions jump straight between Details and Content.

Default theme bumps to 1.1.0 with a single metadata field (`layout`: contained|wide), and `layout.liquid` + `theme.css` are wired to honor it — selecting "wide" on a page strips the `<main>` container's max-width and padding, useful for landing-style homepages.