### PR TITLE
feat: exclude pages from top nav; fix metadata checkbox layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+Project-specific guidance for working in this repository. Phoenix/Elixir
+and HEEx conventions live in `AGENTS.md` — read that too; this file does
+not repeat it.
+
+## What this is
+
+**Ledger** — an open-source, multi-tenant publishing platform for blogs
+and small business sites (hosted at ledger-cloud.com). Each site runs on
+its own subdomain; content is Markdown or HTML; the whole thing deploys
+as a single Phoenix/OTP release.
+
+## Architecture map
+
+- **Multi-tenancy** is resolved at the `Host:` header by
+  `LedgerWeb.Plugs.Subdomain` — the site row is looked up by subdomain
+  and assigned to `conn.assigns.current_site`.
+- **Two routers**: `LedgerWeb.PublicRouter` serves site-scoped public
+  URLs (`/`, `/posts/:slug`, `/:slug`); `LedgerWeb.Router` serves the
+  admin + marketing surface on the bare app host.
+- **Themes** are data, not code. A theme is a row in `themes` plus
+  files in object storage (or `priv/themes/` for built-ins). The render
+  pipeline is `Themes.Renderer` → `Loader` (parses + caches templates in
+  `:persistent_term`) → `Sandbox` (Solid/Liquid, no Elixir/DB/FS access)
+  → `Presenter` (the *only* path from schemas to templates). Uploaded
+  theme zips go through `Themes.Package` (validation + install/update).
+- **Per-page theme settings** come from the theme manifest's `metadata`
+  schema, rendered as a form step in `AdminLive.PageForm`, stored in
+  `pages.metadata` jsonb, merged with manifest defaults at render time.
+- **Object storage** is pluggable via `Ledger.Storage.Adapter`
+  (`Local` for dev, `S3` for prod). Call sites are adapter-agnostic.
+- **Content sanitization**: all post/page bodies pass through
+  `Ledger.Content.HTML.Scrubber` (HtmlSanitizeEx). It allows structural
+  tags + `class`/`id` but strips `<script>`, `<style>`, `on*`,
+  `javascript:` URLs, and inline `style`. Theme templates are NOT
+  sanitized (author-trusted).
+
+## Commands
+
+- `mix precommit` — compile (warnings as errors), `deps.unlock --unused`,
+  format, test. **Run this before every commit; it must pass.**
+- `mix test` / `mix test path:line` — tests (creates+migrates test DB).
+- `mix phx.server` — dev server. Public site at `http://<slug>.lvh.me:4000`,
+  admin at `http://localhost:4000`. Seeded login:
+  `admin@example.com` / `password1234`.
+- `mix ecto.gen.migration name` then edit, then `mix ecto.migrate`.
+
+## Build/runtime gotchas (learned the hard way)
+
+- **Never hand-delete `.beam` files and rely on plain `mix compile`.**
+  The incremental compiler keys off source mtime, not beam presence, so
+  a deleted module won't regenerate and the server boots with it
+  missing (`__live__/0 undefined`). Use `mix compile --force` or don't
+  delete beams.
+- The dev code reloader recompiles on request, but a long-running server
+  across many edits can serve stale LiveView modules. When in doubt,
+  restart the server; hard-reload the browser to drop stale sockets.
+- `Loader` caches parsed theme templates/CSS in `:persistent_term` per
+  VM. Theme content changes need `Loader.invalidate/1` (or a restart).
+  Page *content* is read fresh per request — no cache, no restart.
+- Theme zip = `manifest.json` + `theme.css` + `templates/`. The
+  `pages/` HTML in a theme repo is pasted into Ledger as page content,
+  not part of the zip. Re-uploading a theme updates in place only if
+  the manifest `version` is a strictly-newer SemVer.
+
+## Versioning — bump before every commit
+
+**Before every commit, bump `version:` in `mix.exs`**, sized to the
+change (SemVer):
+
+- **patch** (`x.y.Z`) — bug fixes, copy tweaks, small CSS/UI
+  adjustments, refactors with no behavior change.
+- **minor** (`x.Y.0`) — a new user-facing feature, a new option/field,
+  a new module or endpoint, a schema addition that's backward
+  compatible.
+- **major** (`X.0.0`) — a breaking change: removed/renamed public
+  behavior, a migration that drops/renames columns other code depends
+  on, an incompatible API change.
+
+Pick the highest level any change in the commit reaches (one breaking
+change in an otherwise small commit → major). Include the bump in the
+same commit as the change it describes, and mention the new version in
+the commit body when it's notable.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -691,6 +691,18 @@ code { font-family: ui-monospace, Menlo, monospace; font-size: 0.9em; background
 .form input:focus, .form textarea:focus, .form select:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: var(--accent); }
 .form small { color: var(--muted); font-weight: 400; }
 .form .checkbox { flex-direction: row; align-items: center; gap: 0.5rem; }
+/* Boolean metadata field: checkbox beside a stacked label + hint.
+   The wrapper is a <div> (not a <label>) so the generic
+   `.form label { flex-direction: column }` rule can't stretch the
+   checkbox full-width. */
+.settings-checkbox { display: flex; align-items: flex-start; gap: 0.6rem; }
+.settings-checkbox input[type="checkbox"] {
+  width: auto;
+  flex: none;
+  margin: 0.2rem 0 0;
+  accent-color: var(--accent);
+}
+.settings-checkbox .settings-checkbox-text { gap: 0.15rem; cursor: pointer; }
 .form-actions { display: flex; gap: 1rem; align-items: center; margin-top: 0.5rem; }
 .errors { background: #fef2f2; color: var(--danger); list-style: none; padding: 0.6rem 0.9rem; border-radius: 6px; font-size: 0.85rem; margin: 0; }
 

--- a/lib/ledger/content/page.ex
+++ b/lib/ledger/content/page.ex
@@ -8,6 +8,7 @@ defmodule Ledger.Content.Page do
     field :body, :string, default: ""
     field :format, :string, default: "markdown"
     field :published, :boolean, default: false
+    field :show_in_nav, :boolean, default: true
     field :metadata, :map, default: %{}
     belongs_to :site, Ledger.Sites.Site
     timestamps(type: :utc_datetime)
@@ -15,7 +16,7 @@ defmodule Ledger.Content.Page do
 
   def changeset(page, attrs) do
     page
-    |> cast(attrs, [:title, :slug, :body, :format, :published, :metadata, :site_id])
+    |> cast(attrs, [:title, :slug, :body, :format, :published, :show_in_nav, :metadata, :site_id])
     |> validate_required([:title, :site_id])
     |> validate_inclusion(:format, ~w(markdown html blog))
     |> ensure_slug()

--- a/lib/ledger_web/controllers/public_controller.ex
+++ b/lib/ledger_web/controllers/public_controller.ex
@@ -80,10 +80,13 @@ defmodule LedgerWeb.PublicController do
     send_themed(conn, body)
   end
 
-  # Hide the site's designated homepage page from the nav list — it's already
-  # reachable via the brand link at `/`.
+  # The nav excludes: the site's designated homepage (already reachable
+  # via the brand link at `/`), and any page explicitly hidden from the
+  # nav via its `show_in_nav` flag.
   defp nav_pages(site, pages) do
-    Enum.reject(pages, &(&1.id == site.homepage_page_id))
+    Enum.reject(pages, fn p ->
+      p.id == site.homepage_page_id or p.show_in_nav == false
+    end)
   end
 
   defp require_site(conn, _opts) do

--- a/lib/ledger_web/live/admin/page_form.ex
+++ b/lib/ledger_web/live/admin/page_form.ex
@@ -243,6 +243,7 @@ defmodule LedgerWeb.AdminLive.PageForm do
       "format" => page.format,
       "body" => page.body,
       "published" => to_string(page.published),
+      "show_in_nav" => to_string(page.show_in_nav),
       "metadata" => page.metadata || %{}
     }
   end
@@ -431,6 +432,23 @@ defmodule LedgerWeb.AdminLive.PageForm do
         <small>URL: <code>/{Ecto.Changeset.get_field(@changeset, :slug) || "your-slug"}</code></small>
       </label>
 
+      <div class="settings-checkbox">
+        <input type="hidden" name="page[show_in_nav]" value="false" />
+        <input
+          type="checkbox"
+          id="page-show-in-nav"
+          name="page[show_in_nav]"
+          value="true"
+          checked={@form[:show_in_nav].value not in [false, "false"]}
+        />
+        <label for="page-show-in-nav" class="settings-checkbox-text">
+          <span>Show in top navigation</span>
+          <small>
+            Untick to keep this page out of the nav bar (e.g. a privacy policy or landing page). It stays reachable by its URL.
+          </small>
+        </label>
+      </div>
+
       <input type="hidden" name="page[format]" value={@format} />
     </form>
 
@@ -599,17 +617,20 @@ defmodule LedgerWeb.AdminLive.PageForm do
     assigns = assign(assigns, :checked?, truthy?(assigns.value, assigns.field.default))
 
     ~H"""
-    <label class="checkbox-label">
+    <div class="settings-checkbox">
       <input type="hidden" name={"page[metadata][" <> @field.key <> "]"} value="false" />
       <input
         type="checkbox"
+        id={"meta-" <> @field.key}
         name={"page[metadata][" <> @field.key <> "]"}
         value="true"
         checked={@checked?}
       />
-      <span>{@field.label}</span>
-      <small :if={@field.description}>{@field.description}</small>
-    </label>
+      <label for={"meta-" <> @field.key} class="settings-checkbox-text">
+        <span>{@field.label}</span>
+        <small :if={@field.description}>{@field.description}</small>
+      </label>
+    </div>
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.2.0",
+      version: "1.3.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260516181843_add_show_in_nav_to_pages.exs
+++ b/priv/repo/migrations/20260516181843_add_show_in_nav_to_pages.exs
@@ -1,0 +1,12 @@
+defmodule Ledger.Repo.Migrations.AddShowInNavToPages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:pages) do
+      # Whether a published page appears in the theme's top navigation.
+      # Platform-level (not theme metadata) so it works regardless of the
+      # active theme and survives theme switches.
+      add :show_in_nav, :boolean, null: false, default: true
+    end
+  end
+end


### PR DESCRIPTION
mix.exs 1.2.0 -> 1.3.0 (minor: new user-facing page option).

- New platform-level `pages.show_in_nav` boolean (default true). It's a Page field, not theme metadata, so it works across every theme and survives theme switches. `PublicController.nav_pages/2` now also drops pages with show_in_nav == false (still reachable by URL). Surfaced as a checkbox in the page editor's Details step (always available, not gated on the theme having metadata).

- Fixed the broken boolean metadata field layout: it used `class="checkbox-label"` with no matching CSS, so `.form label { flex-direction: column }` stacked and stretched the checkbox full width above its label (the offset in the screenshot). Now a non-<label> `.settings-checkbox` wrapper: checkbox beside a stacked title + hint, with its own scoped CSS.

- Added CLAUDE.md: project/architecture map, commands, build gotchas, and a versioning policy — bump mix.exs before every commit, sized to the change (patch/minor/major by SemVer).