### PR TITLE
fix: correct check_origin MFA argument order (prod outage)

### DIFF
--- a/lib/ledger_web/check_origin.ex
+++ b/lib/ledger_web/check_origin.ex
@@ -9,16 +9,18 @@ defmodule LedgerWeb.CheckOrigin do
 
       check_origin: {LedgerWeb.CheckOrigin, :allowed?, [%{host: host, app_hosts: app_hosts}]}
 
-  Phoenix appends the request origin `%URI{}` as the final argument.
+  Phoenix invokes the MFA with the request origin `%URI{}` as the
+  FIRST argument, followed by the configured args — so the URI comes
+  before the config map here.
   """
-  def allowed?(%{host: host, app_hosts: app_hosts}, %URI{host: origin_host})
+  def allowed?(%URI{host: origin_host}, %{host: host, app_hosts: app_hosts})
       when is_binary(origin_host) do
     origin_host == host or
       Enum.any?(app_hosts, &String.ends_with?(origin_host, "." <> &1)) or
       active_custom_domain?(origin_host)
   end
 
-  def allowed?(_config, _uri), do: false
+  def allowed?(_uri, _config), do: false
 
   defp active_custom_domain?(origin_host) do
     origin_host in Ledger.Sites.list_active_custom_domains()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.6.2",
+      version: "1.6.3",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/ledger_web/custom_domain_routing_test.exs
+++ b/test/ledger_web/custom_domain_routing_test.exs
@@ -64,18 +64,22 @@ defmodule LedgerWeb.CustomDomainRoutingTest do
   describe "CheckOrigin.allowed?/2" do
     @config %{host: "ledger-cloud.com", app_hosts: ["ledger-cloud.com"]}
 
+    # Phoenix invokes the {M,F,A} check_origin callback with the
+    # request %URI{} FIRST, then the configured args. These tests call
+    # it in that exact order so the argument contract can't regress
+    # (getting it wrong rejected every origin in prod).
     test "allows the bare app host and its subdomains" do
-      assert CheckOrigin.allowed?(@config, URI.parse("https://ledger-cloud.com"))
-      assert CheckOrigin.allowed?(@config, URI.parse("https://acme.ledger-cloud.com"))
+      assert CheckOrigin.allowed?(URI.parse("https://ledger-cloud.com"), @config)
+      assert CheckOrigin.allowed?(URI.parse("https://acme.ledger-cloud.com"), @config)
     end
 
     test "rejects an unknown foreign host" do
-      refute CheckOrigin.allowed?(@config, URI.parse("https://evil.example.com"))
+      refute CheckOrigin.allowed?(URI.parse("https://evil.example.com"), @config)
     end
 
     test "allows an active custom domain", %{site: site} do
       activate(site, "blog.example.com")
-      assert CheckOrigin.allowed?(@config, URI.parse("https://blog.example.com"))
+      assert CheckOrigin.allowed?(URI.parse("https://blog.example.com"), @config)
     end
   end
 end


### PR DESCRIPTION
Phoenix invokes the {M,F,A} check_origin callback with the request %URI{} as the FIRST argument, followed by the configured args. LedgerWeb.CheckOrigin.allowed?/2 had the config map first and the URI second, so no function head matched and it fell through to the catch-all `-> false`. That rejected EVERY socket origin in prod — including https://ledger-cloud.com — breaking all LiveViews ("Could not check origin for Phoenix.Socket transport").

- Flip allowed?/2 to take %URI{} first, then the config map.
- Tests now call it in Phoenix's real order (URI first) so the argument contract can't silently regress.

Version bumped 1.6.2 -> 1.6.3 (critical bug fix).