### PR TITLE
fix: compare apex IPs parsed, not as strings; degeneric-ize copy

### DIFF
--- a/lib/ledger/custom_domains.ex
+++ b/lib/ledger/custom_domains.ex
@@ -92,12 +92,12 @@ defmodule Ledger.CustomDomains do
         |> state_changeset(%{
           custom_domain_status: "cert_provisioning",
           custom_domain_last_checked_at: now,
-          custom_domain_last_error: "Certificate not ready yet (Fly status: #{status})"
+          custom_domain_last_error: "Certificate not ready yet (status: #{status})"
         })
         |> Repo.update()
 
       {:error, reason} ->
-        fail(site, "Fly certificate check failed: #{inspect(reason)}", now)
+        fail(site, "Certificate status check failed: #{inspect(reason)}", now)
     end
   end
 
@@ -176,7 +176,7 @@ defmodule Ledger.CustomDomains do
         |> Repo.update()
 
       {:error, reason} ->
-        fail(site, "Fly certificate request failed: #{inspect(reason)}", now)
+        fail(site, "Certificate request failed: #{inspect(reason)}", now)
     end
   end
 
@@ -194,27 +194,55 @@ defmodule Ledger.CustomDomains do
   # cannot hold a CNAME (RFC 1034/2181), so it instead points A/AAAA
   # records at the Fly app's IPs. Either is acceptable.
   defp check_delegation(%Site{custom_domain: domain}) do
-    cond do
-      cname_target() in DnsResolver.lookup_cname(domain) -> :ok
-      apex_points_at_fly?(domain) -> :ok
-      true -> {:error, delegation_error(domain)}
+    if cname_target() in DnsResolver.lookup_cname(domain) do
+      :ok
+    else
+      check_apex_delegation(domain)
     end
   end
 
-  defp apex_points_at_fly?(domain) do
+  defp check_apex_delegation(domain) do
     case FlyClient.get_ips() do
-      {:ok, [_ | _] = fly_ips} ->
-        resolved = DnsResolver.lookup_a(domain) ++ DnsResolver.lookup_aaaa(domain)
-        resolved != [] and Enum.all?(resolved, &(&1 in fly_ips))
+      {:ok, []} ->
+        {:error,
+         "#{domain} has no CNAME to #{cname_target()}, and there are no IP " <>
+           "addresses available to point an apex domain at"}
 
-      _ ->
-        false
+      {:ok, fly_ips} ->
+        resolved = DnsResolver.lookup_a(domain) ++ DnsResolver.lookup_aaaa(domain)
+
+        cond do
+          resolved == [] ->
+            {:error, "#{domain} has no CNAME to #{cname_target()} and no A/AAAA records yet"}
+
+          ips_subset?(resolved, fly_ips) ->
+            :ok
+
+          true ->
+            {:error,
+             "#{domain} points at #{Enum.join(resolved, ", ")} but the required " <>
+               "IP addresses are #{Enum.join(fly_ips, ", ")} — update the A/AAAA records to match"}
+        end
+
+      {:error, reason} ->
+        {:error, "Couldn't confirm apex delegation: #{reason}"}
     end
   end
 
-  defp delegation_error(domain) do
-    "#{domain} is not delegated to Ledger: add a CNAME to #{cname_target()} " <>
-      "(subdomain) or A/AAAA records pointing at the Fly app IPs (apex)"
+  # IPv6 (and IPv4) addresses have several valid textual forms, so
+  # compare parsed addresses rather than strings — `:inet.ntoa` (our
+  # resolved value) and Fly's API string can render the same address
+  # differently (`::` placement, leading zeros, case).
+  defp ips_subset?(resolved, fly_ips) do
+    fly = MapSet.new(fly_ips, &parse_ip/1)
+    Enum.all?(resolved, &MapSet.member?(fly, parse_ip(&1)))
+  end
+
+  defp parse_ip(str) do
+    case :inet.parse_address(String.to_charlist(str)) do
+      {:ok, addr} -> addr
+      _ -> str
+    end
   end
 
   defp fail(site, reason, now) do

--- a/lib/ledger/custom_domains/fly_client.ex
+++ b/lib/ledger/custom_domains/fly_client.ex
@@ -137,20 +137,27 @@ defmodule Ledger.CustomDomains.FlyClient.Http do
       {:ok, status, _headers, resp} when status in 200..299 ->
         decode(resp)
 
-      {:ok, status, _headers, resp} ->
-        {:error, "Fly API HTTP #{status}: #{resp}"}
+      {:ok, status, _headers, _resp} ->
+        {:error, "certificate provider returned HTTP #{status}"}
 
       {:error, reason} ->
-        {:error, "Fly API request failed: #{inspect(reason)}"}
+        {:error, "could not reach the certificate provider: #{inspect(reason)}"}
     end
   end
 
   defp decode(resp) do
     case Jason.decode(resp) do
-      {:ok, %{"errors" => [%{"message" => msg} | _]}} -> {:error, msg}
-      {:ok, %{"data" => data}} when not is_nil(data) -> {:ok, data}
-      {:ok, other} -> {:error, "Unexpected Fly API response: #{inspect(other)}"}
-      {:error, _} -> {:error, "Invalid JSON from Fly API"}
+      {:ok, %{"errors" => [%{"message" => msg} | _]}} ->
+        {:error, msg}
+
+      {:ok, %{"data" => data}} when not is_nil(data) ->
+        {:ok, data}
+
+      {:ok, other} ->
+        {:error, "unexpected response from the certificate provider: #{inspect(other)}"}
+
+      {:error, _} ->
+        {:error, "invalid response from the certificate provider"}
     end
   end
 
@@ -160,16 +167,16 @@ defmodule Ledger.CustomDomains.FlyClient.Http do
   defp credentials do
     case {System.get_env("FLY_API_TOKEN"), System.get_env("FLY_APP_NAME")} do
       {nil, _} ->
-        {:error, "FLY_API_TOKEN is not set — custom-domain certificates are unavailable"}
+        {:error, "certificate management is not configured"}
 
       {_, nil} ->
-        {:error, "FLY_APP_NAME is not set — custom-domain certificates are unavailable"}
+        {:error, "certificate management is not configured"}
 
       {"", _} ->
-        {:error, "FLY_API_TOKEN is not set — custom-domain certificates are unavailable"}
+        {:error, "certificate management is not configured"}
 
       {_, ""} ->
-        {:error, "FLY_APP_NAME is not set — custom-domain certificates are unavailable"}
+        {:error, "certificate management is not configured"}
 
       {token, app} ->
         {:ok, token, app}

--- a/lib/ledger_web/live/admin/domain_setup.ex
+++ b/lib/ledger_web/live/admin/domain_setup.ex
@@ -35,7 +35,7 @@ defmodule LedgerWeb.AdminLive.DomainSetup do
         {:noreply,
          socket
          |> assign_domain(site)
-         |> put_flash(:info, "Domain verified. Requesting an SSL certificate from Fly…")}
+         |> put_flash(:info, "Domain verified. Requesting an SSL certificate…")}
 
       {:error, reason, site} ->
         {:noreply,
@@ -224,8 +224,8 @@ defmodule LedgerWeb.AdminLive.DomainSetup do
                 </div>
 
                 <p :if={@dns.a_records == []} class="domain-error">
-                  Could not fetch the Fly app IPs for apex setup — use the
-                  subdomain (CNAME) option above, or retry later.
+                  Could not load the apex IP addresses — use the subdomain
+                  (CNAME) option above, or retry later.
                 </p>
               </details>
             </div>
@@ -272,8 +272,8 @@ defmodule LedgerWeb.AdminLive.DomainSetup do
                 — {humanize_status(@site.custom_domain_status)}.
               </p>
               <p class="muted">
-                Fly is provisioning a Let's Encrypt certificate. This usually
-                takes a minute or two after DNS has propagated.
+                Your SSL certificate is being provisioned. This usually takes
+                a minute or two after DNS has propagated.
               </p>
               <p :if={@site.custom_domain_last_error} class="domain-error">
                 {@site.custom_domain_last_error}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.6.3",
+      version: "1.6.4",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/ledger/custom_domains_test.exs
+++ b/test/ledger/custom_domains_test.exs
@@ -108,6 +108,23 @@ defmodule Ledger.CustomDomainsTest do
       assert site.custom_domain_status == "cert_provisioning"
     end
 
+    test "verifies apex when the AAAA and Fly IP are the same address in different notation",
+         %{site: site} do
+      {:ok, site} = CustomDomains.set_domain(site, "example.com")
+
+      Application.put_env(:ledger, :dns_stub, %{
+        txt: %{"_ledger-verify.example.com" => [site.custom_domain_token]},
+        aaaa: %{"example.com" => ["2a09:8280:1::115:7075:0"]}
+      })
+
+      # Fly reports the SAME address in expanded form — string compare
+      # would miss this; parsed comparison must not.
+      Application.put_env(:ledger, :fly_stub, %{add: :ok, ips: ["2a09:8280:1:0:0:115:7075:0"]})
+
+      assert {:ok, site} = CustomDomains.verify(site)
+      assert site.custom_domain_status == "cert_provisioning"
+    end
+
     test "fails an apex domain whose A records point elsewhere", %{site: site} do
       {:ok, site} = CustomDomains.set_domain(site, "example.com")
 
@@ -119,7 +136,7 @@ defmodule Ledger.CustomDomainsTest do
       Application.put_env(:ledger, :fly_stub, %{ips: ["66.66.66.66"]})
 
       assert {:error, reason, site} = CustomDomains.verify(site)
-      assert reason =~ "delegated"
+      assert reason =~ "points at" and reason =~ "IP addresses"
       assert site.custom_domain_status == "failed"
     end
   end
@@ -153,7 +170,7 @@ defmodule Ledger.CustomDomainsTest do
       # must degrade gracefully, never raise (which used to crash the
       # whole LiveView via fly_ips/0).
       assert {:error, msg} = Http.get_ips()
-      assert msg =~ "FLY_"
+      assert is_binary(msg) and msg != ""
       assert {:error, _} = Http.add_certificate("blog.example.com")
       assert {:error, _} = Http.get_certificate("blog.example.com")
       assert {:error, _} = Http.delete_certificate("blog.example.com")


### PR DESCRIPTION
Two issues from the live apex setup (joeridijkstra.dev):

1. Apex delegation compared the resolved A/AAAA records to the app's IPs as strings. IPv6 has many valid textual forms, so :inet.ntoa (resolved) and the provider's API string can differ for the SAME address — verification failed ("not delegated") despite correct DNS. Now both sides are parsed with :inet.parse_address/1 and compared as addresses. Delegation errors are also specific now (shows resolved vs expected IPs, or the real failure reason).

2. User-facing copy and error messages no longer name "Fly" or leak FLY_API_TOKEN/FLY_APP_NAME — tenants see a generic "certificate provider" / "certificate management is not configured". Internal module names and code comments are unchanged.

Regression test: an AAAA in compressed form still verifies against the same address in expanded form.

Version 1.6.3 -> 1.6.4.