### PR TITLE
fix: tidy account + signup screens (v1.9.1)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -457,6 +457,42 @@ button.danger {
 }
 button.danger:hover { filter: brightness(0.92); }
 
+.account-email { font-weight: 600; margin: 0 0 0.25rem; }
+
+dialog.modal {
+  border: none;
+  border-radius: 12px;
+  padding: 0;
+  width: min(420px, 92vw);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.22);
+}
+dialog.modal::backdrop { background: rgba(15, 23, 42, 0.45); }
+.modal-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.5rem;
+}
+.modal-card h2 { margin: 0; font-size: 1.05rem; }
+.modal-card label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+}
+.modal-card input {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  font: inherit;
+}
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
 .sso-divider {
   display: flex;
   align-items: center;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -57,6 +57,21 @@ window.addEventListener("ledger:copy", e => {
   })
 })
 
+// Sign-up: block submit unless the two password fields match. Uses the
+// native validity bubble — no server round-trip, no LiveView needed.
+function wirePasswordConfirm(form) {
+  const pw = form.querySelector("input[name='user[password]']")
+  const confirm = form.querySelector("input[name='user[password_confirmation]']")
+  if (!pw || !confirm) return
+  const check = () => {
+    const mismatch = confirm.value && confirm.value !== pw.value
+    confirm.setCustomValidity(mismatch ? "Passwords do not match" : "")
+  }
+  pw.addEventListener("input", check)
+  confirm.addEventListener("input", check)
+}
+document.querySelectorAll("form[data-confirm-password]").forEach(wirePasswordConfirm)
+
 // connect if there are any LiveViews on the page
 liveSocket.connect()
 

--- a/lib/ledger_web/controllers/account_html.ex
+++ b/lib/ledger_web/controllers/account_html.ex
@@ -2,72 +2,98 @@ defmodule LedgerWeb.AccountHTML do
   use LedgerWeb, :html
 
   alias Ledger.Accounts.User
+  alias LedgerWeb.AdminLive.Components
 
   attr :user, :map, required: true
   attr :password_changeset, :map, required: true
 
   def show(assigns) do
     ~H"""
-    <div class="auth-page">
-      <div class="auth-card">
-        <h1>Account</h1>
-
-        <p :if={Phoenix.Flash.get(@flash, :error)} class="error">
-          {Phoenix.Flash.get(@flash, :error)}
-        </p>
-        <p :if={Phoenix.Flash.get(@flash, :info)} class="meta">
-          {Phoenix.Flash.get(@flash, :info)}
-        </p>
-
-        <section>
+    <Components.shell title="Account" current_user={@user} flash={@flash}>
+      <div class="settings-section">
+        <header class="settings-section-head">
           <h2>Email</h2>
-          <p class="meta">{@user.email}</p>
+          <p>The address you sign in with and where account email is sent.</p>
+        </header>
+        <div class="settings-fields">
+          <p class="account-email">{@user.email}</p>
           <%= if User.confirmed?(@user) do %>
             <p class="meta">✓ Confirmed</p>
           <% else %>
             <p class="meta">Not confirmed yet.</p>
             <form action={~p"/confirm"} method="post">
               <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
-              <button type="submit">Resend confirmation email</button>
+              <button type="submit" class="btn">Resend confirmation email</button>
             </form>
           <% end %>
-        </section>
+        </div>
+      </div>
 
-        <section>
-          <h2>Change password</h2>
-          <form action={~p"/account/password"} method="post">
-            <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
-            <.error_list changeset={@password_changeset} />
-            <label>
-              Current password <input type="password" name="current_password" required />
-            </label>
-            <label>
-              New password (min 8 chars)
-              <input type="password" name="user[password]" required minlength="8" />
-            </label>
-            <button type="submit">Update password</button>
-          </form>
-        </section>
+      <div class="settings-section">
+        <header class="settings-section-head">
+          <h2>Password</h2>
+          <p>Used for email / password sign-in.</p>
+        </header>
+        <div class="settings-fields">
+          <button
+            type="button"
+            class="btn"
+            onclick="document.getElementById('pw-modal').showModal()"
+          >
+            Change password…
+          </button>
+        </div>
+      </div>
 
-        <section class="danger-zone">
+      <div class="settings-section danger-zone">
+        <header class="settings-section-head">
           <h2>Disable account</h2>
-          <p class="meta">
-            This disables your account and takes all of your sites offline immediately.
-            You won't be able to sign back in. This cannot be undone from here.
+          <p>
+            Disables your account and takes all of your sites offline immediately.
+            You won't be able to sign back in, and this can't be undone here.
           </p>
+        </header>
+        <div class="settings-fields">
           <form
             action={~p"/account/disable"}
             method="post"
             onsubmit="return confirm('Disable your account and take all your sites offline? You will be logged out and cannot undo this yourself.');"
           >
             <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
-            <button type="submit" class="danger">Disable my account</button>
+            <button type="submit" class="btn btn-danger">Disable my account</button>
           </form>
-        </section>
-
-        <p class="meta"><a href={~p"/sites"}>Back to your sites</a></p>
+        </div>
       </div>
-    </div>
+
+      <dialog
+        id="pw-modal"
+        class="modal"
+        open={@password_changeset.action != nil}
+      >
+        <form action={~p"/account/password"} method="post" class="modal-card">
+          <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+          <h2>Change password</h2>
+          <.error_list changeset={@password_changeset} />
+          <label>
+            Current password <input type="password" name="current_password" required />
+          </label>
+          <label>
+            New password (min 8 chars)
+            <input type="password" name="user[password]" required minlength="8" />
+          </label>
+          <div class="modal-actions">
+            <button
+              type="button"
+              class="btn"
+              onclick="document.getElementById('pw-modal').close()"
+            >
+              Cancel
+            </button>
+            <button type="submit" class="btn btn-primary">Update password</button>
+          </div>
+        </form>
+      </dialog>
+    </Components.shell>
     """
   end
 

--- a/lib/ledger_web/controllers/registration_html.ex
+++ b/lib/ledger_web/controllers/registration_html.ex
@@ -7,7 +7,7 @@ defmodule LedgerWeb.RegistrationHTML do
       <div class="auth-card">
         <h1>Create your Ledger account</h1>
 
-        <form action={~p"/signup"} method="post">
+        <form action={~p"/signup"} method="post" data-confirm-password>
           <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
           <.error_list changeset={@changeset} />
           <label>
@@ -23,6 +23,10 @@ defmodule LedgerWeb.RegistrationHTML do
           <label>
             Password (min 8 chars)
             <input type="password" name="user[password]" required minlength="8" />
+          </label>
+          <label>
+            Confirm password
+            <input type="password" name="user[password_confirmation]" required minlength="8" />
           </label>
           <button type="submit">Create account</button>
         </form>
@@ -41,7 +45,7 @@ defmodule LedgerWeb.RegistrationHTML do
 
   defp error_list(assigns) do
     ~H"""
-    <ul :if={@changeset.errors != []} class="errors">
+    <ul :if={@changeset.action && @changeset.errors != []} class="errors">
       <li :for={{field, {msg, _}} <- @changeset.errors}>{field}: {msg}</li>
     </ul>
     """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.9.0",
+      version: "1.9.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
1. Signup no longer shows validation errors on first load — the error list only renders once the changeset has an action (i.e. after Create account is pressed).
2. Signup has a Confirm password field with a native frontend match check (app.js, setCustomValidity — blocks submit, no round-trip).
3. Account page now uses the admin shell/sidebar like site settings (settings-section layout), and the password change is behind a native <dialog> modal that re-opens on validation error.

Bumps to v1.9.1.