### PR TITLE
fix: rebuild account page — drop broken modal, settings-style layout

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -457,41 +457,48 @@ button.danger {
 }
 button.danger:hover { filter: brightness(0.92); }
 
-.account-email { font-weight: 600; margin: 0 0 0.25rem; }
-
-dialog.modal {
-  border: none;
-  border-radius: 12px;
-  padding: 0;
-  width: min(420px, 92vw);
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.22);
+/* Account page (mirrors the settings-section layout) */
+.account-fields { gap: 1.4rem; }
+.account-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
 }
-dialog.modal::backdrop { background: rgba(15, 23, 42, 0.45); }
-.modal-card {
+.account-row-label { font-weight: 600; font-size: 0.9rem; margin-bottom: 0.2rem; }
+.account-row-value { font-size: 0.95rem; }
+.account-hint { font-size: 0.85rem; line-height: 1.55; margin: 0.3rem 0 0; max-width: 48ch; }
+.account-divider { border: 0; border-top: 1px solid var(--rule); margin: 0.4rem 0; }
+.account-form {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: 1.5rem;
+  align-items: flex-start;
+  gap: 0.9rem;
 }
-.modal-card h2 { margin: 0; font-size: 1.05rem; }
-.modal-card label {
+.account-form label {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.875rem;
+  gap: 0.3rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  width: 100%;
+  max-width: 360px;
 }
-.modal-card input {
-  padding: 0.5rem 0.6rem;
+.account-form input {
+  padding: 0.55rem 0.75rem;
   border: 1px solid var(--rule);
   border-radius: 6px;
-  font: inherit;
+  font-size: 0.95rem;
+  font-family: inherit;
+  background: var(--card);
 }
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
+.account-form input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  border-color: var(--accent);
 }
+/* Buttons sit in a flex column — keep them their natural size, not stretched */
+.account-fields .btn { align-self: flex-start; }
 
 .sso-divider {
   display: flex;

--- a/lib/ledger_web/controllers/account_html.ex
+++ b/lib/ledger_web/controllers/account_html.ex
@@ -10,98 +10,85 @@ defmodule LedgerWeb.AccountHTML do
   def show(assigns) do
     ~H"""
     <Components.shell title="Account" current_user={@user} flash={@flash}>
-      <div class="settings-section">
-        <header class="settings-section-head">
-          <h2>Email</h2>
-          <p>The address you sign in with and where account email is sent.</p>
-        </header>
-        <div class="settings-fields">
-          <p class="account-email">{@user.email}</p>
-          <%= if User.confirmed?(@user) do %>
-            <p class="meta">✓ Confirmed</p>
-          <% else %>
-            <p class="meta">Not confirmed yet.</p>
-            <form action={~p"/confirm"} method="post">
-              <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
-              <button type="submit" class="btn">Resend confirmation email</button>
-            </form>
-          <% end %>
+      <div class="wizard">
+        <div class="form settings-form">
+          <section class="settings-section">
+            <header class="settings-section-head">
+              <h2>Personal details</h2>
+              <p>The email you sign in with and where account email is sent.</p>
+            </header>
+
+            <div class="settings-fields account-fields">
+              <div class="account-row">
+                <div>
+                  <div class="account-row-label">Email</div>
+                  <div class="account-row-value">{@user.email}</div>
+                </div>
+                <span class={["pill", (User.confirmed?(@user) && "pill-live") || "pill-draft"]}>
+                  {(User.confirmed?(@user) && "Confirmed") || "Not confirmed"}
+                </span>
+              </div>
+
+              <form :if={not User.confirmed?(@user)} action={~p"/confirm"} method="post">
+                <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+                <button type="submit" class="btn">Resend confirmation email</button>
+              </form>
+            </div>
+          </section>
+
+          <section class="settings-section">
+            <header class="settings-section-head">
+              <h2>Security</h2>
+              <p>Change your password or disable your account.</p>
+            </header>
+
+            <div class="settings-fields account-fields">
+              <form action={~p"/account/password"} method="post" class="account-form">
+                <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+                <.error_list changeset={@password_changeset} />
+                <label>
+                  Current password <input type="password" name="current_password" required />
+                </label>
+                <label>
+                  New password (min 8 chars)
+                  <input type="password" name="user[password]" required minlength="8" />
+                </label>
+                <button type="submit" class="btn btn-primary">Update password</button>
+              </form>
+
+              <hr class="account-divider" />
+
+              <div class="account-row">
+                <div>
+                  <div class="account-row-label">Disable account</div>
+                  <p class="muted account-hint">
+                    Disables your account and takes all of your sites offline immediately.
+                    You won't be able to sign back in, and this can't be undone here.
+                  </p>
+                </div>
+                <form
+                  action={~p"/account/disable"}
+                  method="post"
+                  onsubmit="return confirm('Disable your account and take all your sites offline? You will be logged out and cannot undo this yourself.');"
+                >
+                  <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
+                  <button type="submit" class="btn btn-danger">Disable my account</button>
+                </form>
+              </div>
+            </div>
+          </section>
         </div>
       </div>
-
-      <div class="settings-section">
-        <header class="settings-section-head">
-          <h2>Password</h2>
-          <p>Used for email / password sign-in.</p>
-        </header>
-        <div class="settings-fields">
-          <button
-            type="button"
-            class="btn"
-            onclick="document.getElementById('pw-modal').showModal()"
-          >
-            Change password…
-          </button>
-        </div>
-      </div>
-
-      <div class="settings-section danger-zone">
-        <header class="settings-section-head">
-          <h2>Disable account</h2>
-          <p>
-            Disables your account and takes all of your sites offline immediately.
-            You won't be able to sign back in, and this can't be undone here.
-          </p>
-        </header>
-        <div class="settings-fields">
-          <form
-            action={~p"/account/disable"}
-            method="post"
-            onsubmit="return confirm('Disable your account and take all your sites offline? You will be logged out and cannot undo this yourself.');"
-          >
-            <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
-            <button type="submit" class="btn btn-danger">Disable my account</button>
-          </form>
-        </div>
-      </div>
-
-      <dialog
-        id="pw-modal"
-        class="modal"
-        open={@password_changeset.action != nil}
-      >
-        <form action={~p"/account/password"} method="post" class="modal-card">
-          <input type="hidden" name="_csrf_token" value={Phoenix.Controller.get_csrf_token()} />
-          <h2>Change password</h2>
-          <.error_list changeset={@password_changeset} />
-          <label>
-            Current password <input type="password" name="current_password" required />
-          </label>
-          <label>
-            New password (min 8 chars)
-            <input type="password" name="user[password]" required minlength="8" />
-          </label>
-          <div class="modal-actions">
-            <button
-              type="button"
-              class="btn"
-              onclick="document.getElementById('pw-modal').close()"
-            >
-              Cancel
-            </button>
-            <button type="submit" class="btn btn-primary">Update password</button>
-          </div>
-        </form>
-      </dialog>
     </Components.shell>
     """
   end
 
   attr :changeset, :map, required: true
 
+  # Only after a submit (changeset has an action) — never on first load.
   defp error_list(assigns) do
     ~H"""
-    <ul :if={@changeset.errors != []} class="errors">
+    <ul :if={@changeset.action && @changeset.errors != []} class="errors">
       <li :for={{field, {msg, opts}} <- @changeset.errors}>{field}: {interpolate(msg, opts)}</li>
     </ul>
     """


### PR DESCRIPTION
The native <dialog> modal didn't work in a controller-rendered (dead) view and the sections were cramped/buttons stretched. Rebuilt to match the site-settings page exactly:

- Wrapped in .wizard > .form.settings-form so the cards get the same spacing/reset as Settings (they were stuck together before).
- Two clear sections: 'Personal details' (email + a status pill) and 'Security' (inline change-password form + disable account).
- Removed the modal and all dialog/modal CSS; password form is inline.
- error_list only renders after a submit (changeset has an action) — no more 'password: can't be blank' on first load.
- Buttons no longer stretch full-width in the flex column.