### PR TITLE
feat: keyboard shortcuts for save, publish, and new

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -73,6 +73,38 @@ function wirePasswordConfirm(form) {
 }
 document.querySelectorAll("form[data-confirm-password]").forEach(wirePasswordConfirm)
 
+// Keyboard shortcuts. Pages opt in by adding data-shortcut="save",
+// "publish", or "new" to the relevant button/link.
+//   - Cmd/Ctrl+S        → save
+//   - Cmd/Ctrl+Shift+S  → publish (falls back to save if absent)
+//   - c (no modifier)   → new (ignored while typing in an input)
+function isEditableTarget(el) {
+  if (!el) return false
+  const tag = el.tagName
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable
+}
+
+window.addEventListener("keydown", e => {
+  const mod = e.metaKey || e.ctrlKey
+
+  if (mod && (e.key === "s" || e.key === "S")) {
+    const target =
+      (e.shiftKey && document.querySelector("[data-shortcut='publish']")) ||
+      document.querySelector("[data-shortcut='save']")
+    if (!target) return
+    e.preventDefault()
+    target.click()
+    return
+  }
+
+  if (!mod && !e.altKey && (e.key === "c" || e.key === "C") && !isEditableTarget(e.target)) {
+    const target = document.querySelector("[data-shortcut='new']")
+    if (!target) return
+    e.preventDefault()
+    target.click()
+  }
+})
+
 // connect if there are any LiveViews on the page
 liveSocket.connect()
 

--- a/lib/ledger_web/live/admin/page_form.ex
+++ b/lib/ledger_web/live/admin/page_form.ex
@@ -509,11 +509,18 @@ defmodule LedgerWeb.AdminLive.PageForm do
       <button type="button" phx-click="back" class="btn">&larr; Back</button>
       <div class="wizard-actions">
         <%= if @editing do %>
-          <button type="submit" form="content-form" class="btn btn-primary">
+          <button type="submit" form="content-form" class="btn btn-primary" data-shortcut="save">
             Save changes
           </button>
         <% else %>
-          <button type="submit" form="content-form" name="action" value="draft" class="btn">
+          <button
+            type="submit"
+            form="content-form"
+            name="action"
+            value="draft"
+            class="btn"
+            data-shortcut="save"
+          >
             Save as draft
           </button>
           <button
@@ -522,6 +529,7 @@ defmodule LedgerWeb.AdminLive.PageForm do
             name="action"
             value="publish"
             class="btn btn-primary"
+            data-shortcut="publish"
           >
             Save &amp; publish
           </button>

--- a/lib/ledger_web/live/admin/page_index.ex
+++ b/lib/ledger_web/live/admin/page_index.ex
@@ -36,7 +36,13 @@ defmodule LedgerWeb.AdminLive.PageIndex do
     ~H"""
     <.shell title="Pages" site={@site} current_user={@current_user} flash={@flash} active={:pages}>
       <:actions>
-        <.link navigate={~p"/#{@site.slug}/pages/new"} class="btn btn-primary">+ New page</.link>
+        <.link
+          navigate={~p"/#{@site.slug}/pages/new"}
+          class="btn btn-primary"
+          data-shortcut="new"
+        >
+          + New page
+        </.link>
       </:actions>
 
       <table :if={@pages != []} class="table">

--- a/lib/ledger_web/live/admin/post_form.ex
+++ b/lib/ledger_web/live/admin/post_form.ex
@@ -372,11 +372,18 @@ defmodule LedgerWeb.AdminLive.PostForm do
       <button type="button" phx-click="back" class="btn">&larr; Back</button>
       <div class="wizard-actions">
         <%= if @editing do %>
-          <button type="submit" form="content-form" class="btn btn-primary">
+          <button type="submit" form="content-form" class="btn btn-primary" data-shortcut="save">
             Save changes
           </button>
         <% else %>
-          <button type="submit" form="content-form" name="action" value="draft" class="btn">
+          <button
+            type="submit"
+            form="content-form"
+            name="action"
+            value="draft"
+            class="btn"
+            data-shortcut="save"
+          >
             Save as draft
           </button>
           <button
@@ -385,6 +392,7 @@ defmodule LedgerWeb.AdminLive.PostForm do
             name="action"
             value="publish"
             class="btn btn-primary"
+            data-shortcut="publish"
           >
             Save &amp; publish
           </button>

--- a/lib/ledger_web/live/admin/post_index.ex
+++ b/lib/ledger_web/live/admin/post_index.ex
@@ -35,7 +35,13 @@ defmodule LedgerWeb.AdminLive.PostIndex do
     ~H"""
     <.shell title="Posts" site={@site} current_user={@current_user} flash={@flash} active={:posts}>
       <:actions>
-        <.link navigate={~p"/#{@site.slug}/posts/new"} class="btn btn-primary">+ New post</.link>
+        <.link
+          navigate={~p"/#{@site.slug}/posts/new"}
+          class="btn btn-primary"
+          data-shortcut="new"
+        >
+          + New post
+        </.link>
       </:actions>
 
       <table :if={@posts != []} class="table">

--- a/lib/ledger_web/live/admin/site_settings.ex
+++ b/lib/ledger_web/live/admin/site_settings.ex
@@ -285,7 +285,9 @@ defmodule LedgerWeb.AdminLive.SiteSettings do
 
           <div class="wizard-footer">
             <.link navigate={~p"/#{@site.slug}"} class="btn">Cancel</.link>
-            <button type="submit" class="btn btn-primary">Save settings</button>
+            <button type="submit" class="btn btn-primary" data-shortcut="save">
+              Save settings
+            </button>
           </div>
         </.form>
       </div>

--- a/lib/ledger_web/live/admin/upload_index.ex
+++ b/lib/ledger_web/live/admin/upload_index.ex
@@ -94,7 +94,14 @@ defmodule LedgerWeb.AdminLive.UploadIndex do
     ~H"""
     <.shell title="Uploads" site={@site} current_user={@current_user} flash={@flash} active={:uploads}>
       <:actions>
-        <button type="button" phx-click="open_modal" class="btn btn-primary">+ New upload</button>
+        <button
+          type="button"
+          phx-click="open_modal"
+          class="btn btn-primary"
+          data-shortcut="new"
+        >
+          + New upload
+        </button>
       </:actions>
 
       <div :if={@uploads_list == []} class="empty-state empty-state-illustrated">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.9.1",
+      version: "1.10.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Cmd/Ctrl+S saves the current post/page/settings form. Cmd+Shift+S publishes a new post/page (falls back to save when there's no publish button). Plain `c` on an index page triggers the primary "new" action (navigates to the wizard, or opens the upload modal). `c` is ignored while focus is in an input or editor.

v1.10.0.