### PR TITLE
feat: homepage footer auth links and lower-friction site creation (v1…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ ledger-*.tar
 # Ignore digested assets cache.
 /priv/static/cache_manifest.json
 
+# Ignore `mix phx.digest` output for committed static files (images,
+# favicon, robots): content-hashed copies and gzipped versions.
+# Regenerated at deploy time; the source files stay tracked.
+/priv/static/**/*.gz
+/priv/static/**/*-????????????????????????????????.*
+
 # Local-disk Storage adapter target. Source themes live in /priv/themes/.
 /priv/uploads/
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -574,28 +574,11 @@ button.danger:hover { filter: brightness(0.92); }
   border-radius: 14px;
   padding: 1.25rem 1.4rem;
   box-shadow: var(--shadow-sm);
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
   display: flex;
   align-items: center;
   gap: 1rem;
   position: relative;
   overflow: hidden;
-}
-.stat::after {
-  content: "";
-  position: absolute;
-  right: -25px;
-  top: -25px;
-  width: 90px;
-  height: 90px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(37, 99, 235, 0.06), transparent 70%);
-  pointer-events: none;
-}
-.stat:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-  border-color: var(--rule-strong);
 }
 .stat .stat-icon {
   width: 44px;
@@ -1459,16 +1442,19 @@ button.danger:hover { filter: brightness(0.92); }
   font-size: 0.9rem;
   font-weight: 500;
 }
-.dialog-form input[type="text"] {
+.dialog-form input[type="text"],
+.dialog-form textarea {
   padding: 0.55rem 0.75rem;
   border: 1px solid var(--rule);
   border-radius: 6px;
   font-size: 0.95rem;
   font-family: inherit;
+  resize: none;
   background: var(--card);
   color: var(--fg);
 }
-.dialog-form input[type="text"]:focus {
+.dialog-form input[type="text"]:focus,
+.dialog-form textarea:focus {
   outline: 2px solid var(--accent);
   outline-offset: -1px;
   border-color: var(--accent);
@@ -1995,6 +1981,18 @@ button.danger:hover { filter: brightness(0.92); }
   letter-spacing: 0.02em;
   font-size: 0.75rem;
 }
+.landing-footer-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+.landing-footer-links a {
+  color: var(--landing-muted);
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: color 0.15s ease;
+}
+.landing-footer-links a:hover { color: var(--landing-fg); }
 
 @media (max-width: 800px) {
   .landing-hero {

--- a/lib/ledger_web/controllers/page_html/home.html.heex
+++ b/lib/ledger_web/controllers/page_html/home.html.heex
@@ -32,8 +32,8 @@
 
   <section class="landing-hero">
     <div class="hero-inner">
-      <span class="hero-eyebrow">Open-source publishing platform</span>
-      <h1>Publishing for teams that want to ship, not configure.</h1>
+      <span class="hero-eyebrow">Open-source platform</span>
+      <h1>Simple websites without the complexity of traditional CMS platforms.</h1>
       <p class="hero-lede">
         Ledger is a hosted platform for blogs and small business sites. Each
         site runs on its own subdomain, content is written in Markdown or
@@ -245,6 +245,14 @@
       <span class="brand-mark">●</span>
       <strong>Ledger</strong>
       <span class="landing-version">v{Application.spec(:ledger, :vsn)}</span>
+    </div>
+    <div class="landing-footer-links">
+      <%= if assigns[:current_user] do %>
+        <.link navigate={~p"/sites"}>Dashboard</.link>
+      <% else %>
+        <.link navigate={~p"/login"}>Log in</.link>
+        <.link navigate={~p"/signup"}>Sign up</.link>
+      <% end %>
     </div>
     <a
       href="https://github.com/JoeriDijkstra/ledger"

--- a/lib/ledger_web/live/admin/site_index.ex
+++ b/lib/ledger_web/live/admin/site_index.ex
@@ -16,7 +16,8 @@ defmodule LedgerWeb.AdminLive.SiteIndex do
        page_title: "Your sites",
        host: site_host(),
        modal_open?: false,
-       show_errors: false
+       show_errors: false,
+       slug_edited?: false
      )
      |> assign_form(changeset)}
   end
@@ -25,7 +26,7 @@ defmodule LedgerWeb.AdminLive.SiteIndex do
   def handle_event("open_modal", _params, socket) do
     {:noreply,
      socket
-     |> assign(modal_open?: true, show_errors: false)
+     |> assign(modal_open?: true, show_errors: false, slug_edited?: false)
      |> assign_form(Sites.change_site(%Site{}))}
   end
 
@@ -34,16 +35,35 @@ defmodule LedgerWeb.AdminLive.SiteIndex do
   end
 
   def handle_event("validate", %{"site" => params}, socket) do
+    # Auto-derive the slug from the name until the user edits the slug field
+    # directly, after which we leave their value alone.
+    prev_slug = socket.assigns.form[:slug].value || ""
+    incoming_slug = params["slug"] || ""
+
+    slug_edited? =
+      socket.assigns.slug_edited? or (incoming_slug != "" and incoming_slug != prev_slug)
+
+    params =
+      if slug_edited?,
+        do: params,
+        else: Map.put(params, "slug", slugify(params["name"] || ""))
+
     changeset =
       %Site{}
       |> Sites.change_site(params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign_form(socket, changeset)}
+    {:noreply,
+     socket
+     |> assign(slug_edited?: slug_edited?)
+     |> assign_form(changeset)}
   end
 
   def handle_event("save", %{"site" => params}, socket) do
-    params = Map.put(params, "owner_id", socket.assigns.current_user.id)
+    params =
+      params
+      |> Map.put("owner_id", socket.assigns.current_user.id)
+      |> Map.put("title", params["name"])
 
     case Sites.create_site(params) do
       {:ok, site} ->
@@ -59,6 +79,17 @@ defmodule LedgerWeb.AdminLive.SiteIndex do
 
   defp assign_form(socket, changeset) do
     assign(socket, form: to_form(changeset, as: :site), changeset: changeset)
+  end
+
+  # Turn a free-form name into a valid slug: lowercase, non-alphanumeric runs
+  # collapsed to hyphens, trimmed, capped at the schema's 32-char limit.
+  defp slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "-")
+    |> String.trim("-")
+    |> String.slice(0, 32)
+    |> String.trim("-")
   end
 
   defp site_host do
@@ -145,16 +176,8 @@ defmodule LedgerWeb.AdminLive.SiteIndex do
               Slug (subdomain)
               <input type="text" name="site[slug]" value={@form[:slug].value} required />
               <small>
-                Public URL: <code>{(@form[:slug].value || "your-slug") <> "." <> @host}</code>. Lowercase letters, numbers, hyphens only.
+                Public URL: <code>{(@form[:slug].value || "your-slug") <> "." <> @host}</code>. Auto-filled from the name; edit to customize. Lowercase letters, numbers, hyphens only.
               </small>
-            </label>
-
-            <label>
-              Title <input type="text" name="site[title]" value={@form[:title].value} />
-            </label>
-
-            <label>
-              Description <textarea name="site[description]" rows="3">{@form[:description].value}</textarea>
             </label>
 
             <footer class="dialog-footer">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.10.0",
+      version: "1.10.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/ledger_web/controllers/page_controller_test.exs
+++ b/test/ledger_web/controllers/page_controller_test.exs
@@ -3,6 +3,8 @@ defmodule LedgerWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Publishing for teams that want to ship"
+
+    assert html_response(conn, 200) =~
+             "Simple websites without the complexity of traditional CMS platforms."
   end
 end


### PR DESCRIPTION
….10.1)

Homepage:
- Add Log in / Sign up (or Dashboard) links to the landing footer, mirroring the nav's current_user logic, with muted footer-link styling.
- Update the GET / test to match the current hero copy.

Create-site modal:
- Drop the Title and Description fields to reduce friction; Title is now set to the site Name on save (both remain editable in site settings).
- Auto-fill the Slug from the Name as you type, until the slug field is edited directly (tracked via slug_edited?); add a slugify/1 helper.

Also: simplify .stat card styling and gitignore mix phx.digest output.