### PR TITLE
feat: dashed "upload custom theme" placeholder card (v1.11.2)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1211,10 +1211,11 @@ button.danger:hover { filter: brightness(0.92); }
 .theme-picker-card-add {
   flex-direction: column;
   gap: 0.25rem;
+  background: transparent;
   border-style: dashed;
   color: var(--muted);
 }
-.theme-picker-card-add:hover { color: var(--fg); border-color: var(--accent); background: var(--bg); }
+.theme-picker-card-add:hover { color: var(--accent); border-color: var(--accent); text-decoration: none; }
 .theme-picker-card-icon { font-size: 1.25rem; line-height: 1; font-weight: 400; }
 
 @media (max-width: 800px) {
@@ -2115,10 +2116,14 @@ button.danger:hover { filter: brightness(0.92); }
 .theme-grid li { display: block; }
 .theme-card {
   position: relative;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
   height: 100%;
+  /* Fixed height so every card matches across rows regardless of whether
+     it has a description (the description is clamped to keep this true). */
+  min-height: 9rem;
   background: var(--card);
   border: 1px solid var(--rule);
   border-radius: 12px;
@@ -2132,6 +2137,28 @@ button.danger:hover { filter: brightness(0.92); }
   box-shadow: var(--shadow-md);
   border-color: var(--rule-strong);
 }
+/* Dashed, see-through placeholder card linking to the GitHub template.
+   Defined after .theme-card (and its :hover) so these overrides win. */
+.theme-card-add {
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1.1rem 1.15rem;
+  background: transparent;
+  border-style: dashed;
+  border-color: var(--rule-strong);
+  text-align: center;
+  color: var(--muted);
+  box-shadow: none;
+}
+.theme-card-add:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  box-shadow: none;
+  text-decoration: none;
+}
+.theme-card-add-icon { font-size: 1.5rem; line-height: 1; font-weight: 400; }
+.theme-card-add-label { font-weight: 600; font-size: 0.95rem; }
 .theme-card-head {
   display: flex;
   align-items: center;
@@ -2155,6 +2182,12 @@ button.danger:hover { filter: brightness(0.92); }
   color: var(--muted);
   font-size: 0.88rem;
   line-height: 1.5;
+  /* Clamp to two lines so a long description can't make one card (and so
+     its whole row) taller than the rest. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 /* Quiet, icon-only delete in the bottom-right of the card. Fades in
    slightly on card hover and turns destructive-red on its own hover.

--- a/lib/ledger_web/live/admin/site_settings.ex
+++ b/lib/ledger_web/live/admin/site_settings.ex
@@ -199,19 +199,11 @@ defmodule LedgerWeb.AdminLive.SiteSettings do
                     value={t.id}
                     checked={@selected_theme && t.id == @selected_theme.id}
                   />
-                  <span class="theme-picker-card-name">
-                    {t.name}<span :if={t.source == "uploaded"} class="theme-picker-card-tag">uploaded</span>
-                  </span>
+                  <span class="theme-picker-card-name">{t.name}</span>
                 </label>
-                <a
-                  href="https://github.com/JoeriDijkstra/ledger-template"
-                  target="_blank"
-                  rel="noopener"
-                  class="theme-picker-card theme-picker-card-add"
-                >
+                <.link class="theme-picker-card theme-picker-card-add" navigate={~p"/themes"}>
                   <span class="theme-picker-card-icon" aria-hidden="true">+</span>
-                  <span class="theme-picker-card-name">Add a custom theme</span>
-                </a>
+                </.link>
                 <small class="theme-picker-hint">
                   Rendering style applied to the public site.
                 </small>

--- a/lib/ledger_web/live/admin/theme_library.ex
+++ b/lib/ledger_web/live/admin/theme_library.ex
@@ -271,6 +271,18 @@ defmodule LedgerWeb.AdminLive.ThemeLibrary do
             </button>
           </article>
         </li>
+
+        <li>
+          <a
+            href="https://github.com/JoeriDijkstra/ledger-template"
+            target="_blank"
+            rel="noopener"
+            class="theme-card theme-card-add"
+          >
+            <span class="theme-card-add-icon" aria-hidden="true">+</span>
+            <span class="theme-card-add-label">Create theme</span>
+          </a>
+        </li>
       </ul>
 
       <div

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ledger.MixProject do
   def project do
     [
       app: :ledger,
-      version: "1.11.1",
+      version: "1.11.2",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- Add a see-through, dashed placeholder card to the /themes grid linking to the GitHub theme template ("Upload custom theme"); hover turns the text and border accent-blue with no underline.
- Give theme-library cards a fixed min-height and clamp descriptions to two lines so rows stay even after uploading a theme.
- Settings theme picker: make the "add" card a matching transparent dashed placeholder with the same hover, and drop the per-theme "uploaded" tag.