### PR TITLE
feat: token categories, Tailwind theme colors, token-field polish (v2…

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1172,6 +1172,46 @@ button.danger:hover { filter: brightness(0.92); }
   margin: 0 0.15rem;
 }
 
+/* Token category accordions (themes that group tokens by category). */
+.token-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.token-group {
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--card);
+}
+.token-group-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.token-group-summary::-webkit-details-marker { display: none; }
+.token-group-summary::after {
+  content: "▸";
+  color: var(--muted);
+  font-size: 0.8rem;
+  transition: transform 0.15s ease;
+}
+.token-group[open] > .token-group-summary { border-bottom: 1px solid var(--rule); }
+.token-group[open] > .token-group-summary::after { transform: rotate(90deg); }
+.token-group > .settings-fields { padding: 1rem; }
+/* Quick fade/slide when a section opens, just to smooth the reveal. */
+.token-group[open] > .settings-fields { animation: token-group-reveal 0.15s ease-out; }
+@keyframes token-group-reveal {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 /* Theme picker — card grid for the public-site theme selection. */
 .theme-picker {
   border: 0;

--- a/lib/masthead/themes/manifest.ex
+++ b/lib/masthead/themes/manifest.ex
@@ -53,7 +53,8 @@ defmodule Masthead.Themes.Manifest do
           label: String.t(),
           type: String.t(),
           default: String.t(),
-          options: [String.t()] | nil
+          options: [String.t()] | nil,
+          category: String.t() | nil
         }
 
   @type metadata_field :: %{
@@ -313,7 +314,10 @@ defmodule Masthead.Themes.Manifest do
         label: tok["label"],
         type: tok["type"],
         default: tok["default"],
-        options: tok["options"]
+        options: tok["options"],
+        # Optional grouping label; tokens with a category render in an
+        # accordion in the settings UI (uncategorized → "General").
+        category: tok["category"]
       }
     end)
   end

--- a/lib/masthead_web/live/admin/site_settings.ex
+++ b/lib/masthead_web/live/admin/site_settings.ex
@@ -175,13 +175,47 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
             label: t["label"] || t[:label],
             type: t["type"] || t[:type],
             default: t["default"] || t[:default],
-            options: t["options"] || t[:options] || []
+            options: t["options"] || t[:options] || [],
+            category: t["category"] || t[:category]
           }
         end)
 
       _ ->
         []
     end
+  end
+
+  # Decide how to lay out the token fields:
+  #   * `{:flat, tokens}`    — no token declares a category; render as a
+  #     single list (unchanged behaviour).
+  #   * `{:grouped, groups}` — at least one token has a category; render one
+  #     accordion per category, in first-appearance order, with uncategorized
+  #     tokens collected under "General".
+  defp token_groups(theme) do
+    tokens = token_definitions(theme)
+
+    if Enum.any?(tokens, &categorized?/1) do
+      {:grouped, group_tokens(tokens)}
+    else
+      {:flat, tokens}
+    end
+  end
+
+  defp categorized?(%{category: c}) when is_binary(c), do: String.trim(c) != ""
+  defp categorized?(_), do: false
+
+  defp token_category(tok),
+    do: if(categorized?(tok), do: String.trim(tok.category), else: "General")
+
+  defp group_tokens(tokens) do
+    Enum.reduce(tokens, [], fn tok, acc ->
+      cat = token_category(tok)
+
+      case List.keyfind(acc, cat, 0) do
+        nil -> acc ++ [{cat, [tok]}]
+        {^cat, list} -> List.keyreplace(acc, cat, 0, {cat, list ++ [tok]})
+      end
+    end)
   end
 
   defp token_value(form, key) do
@@ -198,6 +232,22 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
     case token_value(form, tok.key) do
       "" -> to_string(tok.default || "")
       value -> value
+    end
+  end
+
+  # Value for a token <input>. Color has no placeholder, so it's pre-filled
+  # with the effective value (override-or-default) to avoid showing black.
+  # Every other input is left at the override only, so the manifest default
+  # surfaces as the placeholder instead.
+  defp token_input_value(form, %{type: "color"} = tok), do: token_display_value(form, tok)
+  defp token_input_value(form, tok), do: token_value(form, tok.key)
+
+  # Always give text inputs a placeholder: the manifest default, or the
+  # token's label when there's no default.
+  defp token_placeholder(tok) do
+    case to_string(tok.default || "") do
+      "" -> to_string(tok.label || "")
+      default -> default
     end
   end
 
@@ -377,15 +427,33 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
               <p>Override the {@selected_theme.name} theme's design tokens.</p>
             </header>
 
-            <div class="settings-fields">
-              <.token_field
-                :for={tok <- token_definitions(@selected_theme)}
-                tok={tok}
-                form={@form}
-                site={@site}
-                site_uploads={@site_uploads}
-              />
-            </div>
+            <%= case token_groups(@selected_theme) do %>
+              <% {:flat, tokens} -> %>
+                <div class="settings-fields">
+                  <.token_field
+                    :for={tok <- tokens}
+                    tok={tok}
+                    form={@form}
+                    site={@site}
+                    site_uploads={@site_uploads}
+                  />
+                </div>
+              <% {:grouped, groups} -> %>
+                <div class="token-groups">
+                  <details :for={{category, tokens} <- groups} class="token-group">
+                    <summary class="token-group-summary">{category}</summary>
+                    <div class="settings-fields">
+                      <.token_field
+                        :for={tok <- tokens}
+                        tok={tok}
+                        form={@form}
+                        site={@site}
+                        site_uploads={@site_uploads}
+                      />
+                    </div>
+                  </details>
+                </div>
+            <% end %>
           </div>
 
           <div :if={@selected_theme} class="settings-section">
@@ -635,9 +703,12 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
         :if={@tok.type != "file" and @tok.type != "select"}
         type={html_input_type(@tok.type)}
         name={"site[theme_tokens][" <> @tok.key <> "]"}
-        value={token_display_value(@form, @tok)}
+        value={token_input_value(@form, @tok)}
+        placeholder={token_placeholder(@tok)}
       />
-      <small :if={@tok.type != "file"}>Default: <code>{@tok.default}</code></small>
+      <small :if={@tok.type == "color" and @tok.default != ""}>
+        Default: <code>{@tok.default}</code>
+      </small>
     </label>
     """
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.2.0",
+      version: "2.3.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/themes/tailwind/manifest.json
+++ b/priv/themes/tailwind/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "Tailwind",
   "slug": "tailwind",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "author": "Masthead",
-  "description": "A clean, website-first theme styled with Tailwind CSS: a full navbar with an uploadable logo, a hero, and a card grid. Tailwind is loaded from its CDN so you can use any utility class — including arbitrary values — directly in your pages.",
+  "description": "A customizable, website-first theme styled with Tailwind CSS: full navbar with an uploadable logo, brand colors for the header/footer/buttons, light or dark header/footer text, a hero, and a card grid. Loaded from the Tailwind CDN so you can use any utility class in your pages.",
   "tokens": [
     {
       "key": "logo",
@@ -18,6 +18,42 @@
       "default": ""
     },
     {
+      "key": "header_text",
+      "label": "Header text (next to logo)",
+      "type": "string",
+      "default": "",
+      "category": "Header"
+    },
+    {
+      "key": "header_color",
+      "label": "Header background",
+      "type": "color",
+      "default": "#ffffff",
+      "category": "Header"
+    },
+    {
+      "key": "header_style",
+      "label": "Header text color",
+      "type": "select",
+      "options": ["dark", "light"],
+      "default": "dark",
+      "category": "Header"
+    },
+    {
+      "key": "header_width",
+      "label": "Header & footer width",
+      "type": "select",
+      "options": ["contained", "full"],
+      "default": "contained",
+      "category": "Header"
+    },
+    {
+      "key": "accent",
+      "label": "Accent color (buttons)",
+      "type": "color",
+      "default": "#4f46e5"
+    },
+    {
       "key": "cta_label",
       "label": "Nav button label",
       "type": "string",
@@ -30,11 +66,19 @@
       "default": ""
     },
     {
-      "key": "header_width",
-      "label": "Header & footer width",
+      "key": "footer_color",
+      "label": "Footer background",
+      "type": "color",
+      "default": "#f9fafb",
+      "category": "Footer"
+    },
+    {
+      "key": "footer_style",
+      "label": "Footer text color",
       "type": "select",
-      "options": ["contained", "full"],
-      "default": "contained"
+      "options": ["dark", "light"],
+      "default": "dark",
+      "category": "Footer"
     }
   ],
   "metadata": [

--- a/priv/themes/tailwind/templates/blog.liquid
+++ b/priv/themes/tailwind/templates/blog.liquid
@@ -17,7 +17,7 @@
     <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {% for p in posts %}
         <a href="{{ p.url }}" class="group rounded-2xl border border-gray-200 p-6 transition hover:border-gray-300 hover:shadow-md">
-          <h3 class="text-lg font-semibold text-gray-900 group-hover:text-indigo-600">{{ p.title | escape }}</h3>
+          <h3 class="text-lg font-semibold text-gray-900 group-hover:text-[var(--accent)]">{{ p.title | escape }}</h3>
           {% if p.excerpt != "" %}<p class="mt-2 text-gray-600">{{ p.excerpt | escape }}</p>{% endif %}
           {% if p.published_at %}<time datetime="{{ p.published_at | iso8601 }}" class="mt-4 block text-sm text-gray-400">{{ p.published_at | strftime: "%b %-d, %Y" }}</time>{% endif %}
         </a>

--- a/priv/themes/tailwind/templates/index.liquid
+++ b/priv/themes/tailwind/templates/index.liquid
@@ -4,7 +4,7 @@
     {% if site.description != "" %}<p class="mx-auto mt-6 max-w-2xl text-lg text-gray-600">{{ site.description | escape }}</p>{% endif %}
     {% if theme.tokens.cta_label != "" %}
       <div class="mt-10">
-        <a href="{{ theme.tokens.cta_url | default: '/' }}" class="inline-block rounded-md bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">{{ theme.tokens.cta_label | escape }}</a>
+        <a href="{{ theme.tokens.cta_url | default: '/' }}" class="inline-block rounded-md bg-[var(--accent)] px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:opacity-90">{{ theme.tokens.cta_label | escape }}</a>
       </div>
     {% endif %}
   </div>
@@ -16,7 +16,7 @@
     <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {% for p in posts %}
         <a href="{{ p.url }}" class="group rounded-2xl border border-gray-200 p-6 transition hover:border-gray-300 hover:shadow-md">
-          <h3 class="text-lg font-semibold text-gray-900 group-hover:text-indigo-600">{{ p.title | escape }}</h3>
+          <h3 class="text-lg font-semibold text-gray-900 group-hover:text-[var(--accent)]">{{ p.title | escape }}</h3>
           {% if p.excerpt != "" %}<p class="mt-2 text-gray-600">{{ p.excerpt | escape }}</p>{% endif %}
           {% if p.published_at %}<time datetime="{{ p.published_at | iso8601 }}" class="mt-4 block text-sm text-gray-400">{{ p.published_at | strftime: "%b %-d, %Y" }}</time>{% endif %}
         </a>

--- a/priv/themes/tailwind/templates/layout.liquid
+++ b/priv/themes/tailwind/templates/layout.liquid
@@ -18,23 +18,29 @@
   <body class="flex min-h-full flex-col bg-white text-gray-900 antialiased">
     {% assign bar = "mx-auto max-w-6xl" %}
     {% if theme.tokens.header_width == "full" %}{% assign bar = "w-full" %}{% endif %}
+    {% assign head_fg = "text-gray-900" %}
+    {% if theme.tokens.header_style == "light" %}{% assign head_fg = "text-white" %}{% endif %}
+    {% assign foot_fg = "text-gray-500" %}
+    {% assign foot_strong = "text-gray-900" %}
+    {% if theme.tokens.footer_style == "light" %}{% assign foot_fg = "text-white/70" %}{% assign foot_strong = "text-white" %}{% endif %}
     {% unless page.metadata.show_navigation == false %}
-      <header class="sticky top-0 z-20 border-b border-gray-200 bg-white/80 backdrop-blur">
+      <header class="sticky top-0 z-20 border-b border-black/10 bg-[var(--header-color)] {{ head_fg }}">
         <div class="{{ bar }} flex items-center gap-6 px-6 py-4">
-          <a href="/" class="flex items-center gap-2 font-semibold tracking-tight text-gray-900">
+          <a href="/" class="flex items-center gap-2 font-semibold tracking-tight {{ head_fg }}">
             {% if theme.tokens.logo != "" %}
               <img src="{{ theme.tokens.logo }}" alt="{{ site.name | escape }}" class="h-8 w-auto" />
             {% else %}
               <span>{{ site.name | escape }}</span>
             {% endif %}
+            {% if theme.tokens.header_text != "" %}<span class="font-medium opacity-80">{{ theme.tokens.header_text | escape }}</span>{% endif %}
           </a>
           {% if pages != empty %}
             <nav class="ml-auto hidden items-center gap-6 sm:flex">
-              {% for p in pages %}<a href="{{ p.url }}" class="text-sm font-medium text-gray-600 hover:text-gray-900">{{ p.title | escape }}</a>{% endfor %}
+              {% for p in pages %}<a href="{{ p.url }}" class="text-sm font-medium opacity-75 transition hover:opacity-100">{{ p.title | escape }}</a>{% endfor %}
             </nav>
           {% endif %}
           {% if theme.tokens.cta_label != "" %}
-            <a href="{{ theme.tokens.cta_url | default: '/' }}" class="{% if pages == empty %}ml-auto {% endif %}rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">{{ theme.tokens.cta_label | escape }}</a>
+            <a href="{{ theme.tokens.cta_url | default: '/' }}" class="{% if pages == empty %}ml-auto {% endif %}rounded-md bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90">{{ theme.tokens.cta_label | escape }}</a>
           {% endif %}
         </div>
       </header>
@@ -45,10 +51,10 @@
     </main>
 
     {% unless page.metadata.show_navigation == false %}
-      <footer class="border-t border-gray-200 bg-gray-50">
-        <div class="{{ bar }} flex flex-wrap items-center justify-between gap-4 px-6 py-8 text-sm text-gray-500">
-          <span class="font-semibold text-gray-900">{{ site.name | escape }}</span>
-          <span>&copy; {{ site.name | escape }} &middot; Built with <a href="https://masthead.site" class="text-gray-700 underline" target="_blank" rel="noopener">Masthead</a></span>
+      <footer class="border-t border-black/10 bg-[var(--footer-color)] {{ foot_fg }}">
+        <div class="{{ bar }} flex flex-wrap items-center justify-between gap-4 px-6 py-8 text-sm">
+          <span class="font-semibold {{ foot_strong }}">{{ site.name | escape }}</span>
+          <span>&copy; {{ site.name | escape }} &middot; Built with <a href="https://masthead.site" class="underline opacity-90 hover:opacity-100" target="_blank" rel="noopener">Masthead</a></span>
         </div>
       </footer>
     {% endunless %}

--- a/priv/themes/tailwind/templates/not_found.liquid
+++ b/priv/themes/tailwind/templates/not_found.liquid
@@ -1,8 +1,8 @@
 <section class="mx-auto max-w-3xl px-6 py-32 text-center">
-  <p class="text-base font-semibold text-indigo-600">404</p>
+  <p class="text-base font-semibold text-[var(--accent)]">404</p>
   <h1 class="mt-4 text-4xl font-bold tracking-tight text-gray-900">Page not found</h1>
   <p class="mt-4 text-gray-600">We couldn't find that page on {{ site.name | escape }}.</p>
   <div class="mt-8">
-    <a href="/" class="inline-block rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500">&larr; Back home</a>
+    <a href="/" class="inline-block rounded-md bg-[var(--accent)] px-5 py-2.5 text-sm font-semibold text-white transition hover:opacity-90">&larr; Back home</a>
   </div>
 </section>

--- a/priv/themes/tailwind/templates/post.liquid
+++ b/priv/themes/tailwind/templates/post.liquid
@@ -14,6 +14,6 @@
   </div>
 
   <footer class="mt-12 border-t border-gray-200 pt-6">
-    <a href="/" class="text-sm font-medium text-indigo-600 hover:text-indigo-500">&larr; Back to {{ site.name | escape }}</a>
+    <a href="/" class="text-sm font-medium text-[var(--accent)] transition hover:opacity-80">&larr; Back to {{ site.name | escape }}</a>
   </footer>
 </article>

--- a/test/masthead/themes/manifest_test.exs
+++ b/test/masthead/themes/manifest_test.exs
@@ -26,6 +26,19 @@ defmodule Masthead.Themes.ManifestTest do
       assert length(tokens) == 6
     end
 
+    test "tokens preserve an optional category" do
+      json = """
+      {"name":"X","slug":"x","version":"1.0.0","tokens":[
+        {"key":"a","label":"A","type":"color","default":"#fff","category":"Header"},
+        {"key":"b","label":"B","type":"string","default":""}
+      ]}
+      """
+
+      assert {:ok, %Manifest{tokens: [a, b]}} = Manifest.parse(json)
+      assert a.category == "Header"
+      assert b.category == nil
+    end
+
     test "select tokens require a non-empty options list" do
       json =
         ~s({"name":"X","slug":"x","version":"1.0.0",) <>

--- a/test/masthead/themes/renderer_test.exs
+++ b/test/masthead/themes/renderer_test.exs
@@ -257,6 +257,54 @@ defmodule Masthead.Themes.RendererTest do
       assert full =~ "w-full"
       refute full =~ "max-w-6xl"
     end
+
+    test "color tokens are injected as CSS vars the templates reference", %{site: site} do
+      {:ok, site} =
+        Sites.update_settings(site, %{
+          "theme_tokens" => %{
+            "accent" => "#ff0000",
+            "header_color" => "#101010",
+            "footer_color" => "#202020",
+            "cta_label" => "Go"
+          }
+        })
+
+      site = Sites.get_site!(site.id)
+      out = Renderer.render_index(%{site: site, posts: [], pages: []})
+
+      assert out =~ "--accent: #ff0000"
+      assert out =~ "--header-color: #101010"
+      assert out =~ "--footer-color: #202020"
+      # Header background + accent button consume the vars.
+      assert out =~ "bg-[var(--header-color)]"
+      assert out =~ "bg-[var(--accent)]"
+    end
+
+    test "header/footer style tokens switch the text colour to light", %{site: site} do
+      # Default (dark text, no CTA/posts) renders nothing white.
+      default = Renderer.render_index(%{site: site, posts: [], pages: []})
+      refute default =~ "text-white"
+
+      {:ok, site} =
+        Sites.update_settings(site, %{
+          "theme_tokens" => %{"header_style" => "light", "footer_style" => "light"}
+        })
+
+      site = Sites.get_site!(site.id)
+      light = Renderer.render_index(%{site: site, posts: [], pages: []})
+
+      assert light =~ "text-white"
+    end
+
+    test "header_text renders next to the brand", %{site: site} do
+      {:ok, site} =
+        Sites.update_settings(site, %{"theme_tokens" => %{"header_text" => "Est. 2026"}})
+
+      site = Sites.get_site!(site.id)
+      out = Renderer.render_index(%{site: site, posts: [], pages: []})
+
+      assert out =~ "Est. 2026"
+    end
   end
 
   describe "page metadata" do

--- a/test/masthead_web/site_settings_live_test.exs
+++ b/test/masthead_web/site_settings_live_test.exs
@@ -32,6 +32,28 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
     %{conn: conn, site: site}
   end
 
+  test "a theme without token categories renders the tokens flat", %{conn: conn, site: site} do
+    # The default theme's only token (accent) has no category → no accordion.
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/settings")
+    refute html =~ "token-group"
+  end
+
+  test "a theme with token categories renders accordions, uncategorized under General", %{
+    conn: conn,
+    site: site
+  } do
+    tailwind = Themes.get_built_in_by_slug("tailwind")
+    {:ok, site} = Sites.update_settings(site, %{"theme_id" => tailwind.id})
+
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/settings")
+
+    assert html =~ "token-group-summary"
+    assert html =~ "Header</summary>"
+    assert html =~ "Footer</summary>"
+    # logo/favicon/accent/cta have no category → grouped under General.
+    assert html =~ "General</summary>"
+  end
+
   test "a file token renders a picker that lists the site's uploads in a modal", %{
     conn: conn,
     site: site


### PR DESCRIPTION
….3.0)

Theme tokens
- Tokens can declare a "category"; the settings UI groups them into collapsible accordions (closed by default, with a quick reveal animation). No category anywhere → flat layout as before; mixed → uncategorized tokens fall under "General".

Tailwind theme
- Add customizable colors/styles: accent (buttons), header background + text color (light/dark), header text beside the logo, footer background
  + text color. Colors flow through CSS vars the templates consume via Tailwind arbitrary values. Tokens categorized into Header / Footer, with the rest under General.

Settings token fields
- Non-color inputs drop the redundant "Default:" label and surface the default as a placeholder instead; the label is kept only for the color input (which has no placeholder). Text inputs always have a placeholder — the default, or the token label when there's no default.