### PR TITLE
feat: admin overview console (users/sites/themes) (v2.4.0)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -822,6 +822,42 @@ button.danger:hover { filter: brightness(0.92); }
 }
 .pill-live { background: var(--good-soft); color: #166534; }
 .pill-draft { background: var(--amber-soft); color: #92400e; }
+.pill-ok { background: var(--good-soft); color: #166534; }
+.pill-warn { background: var(--amber-soft); color: #92400e; }
+.pill-danger { background: #fef2f2; color: #991b1b; }
+
+/* Admin overview (users / sites / themes tables) */
+.admin-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--rule);
+}
+.admin-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 0.6rem 1rem;
+  margin-bottom: -1px;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+}
+.admin-tab:hover { color: var(--fg); }
+.admin-tab.is-active { color: var(--accent); border-bottom-color: var(--accent); }
+/* Admin tables reuse the platform `.table` style; this just allows the
+   wider tables to scroll on narrow viewports and lays out the row's
+   action buttons in a right-aligned cluster. */
+.admin-table-wrap { overflow-x: auto; }
+.admin-row-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+}
 
 /* Format tags (Markdown / HTML / Blog) */
 .format-tag {

--- a/lib/masthead/accounts.ex
+++ b/lib/masthead/accounts.ex
@@ -324,4 +324,19 @@ defmodule Masthead.Accounts do
       {:error, _, reason, _} -> {:error, reason}
     end
   end
+
+  # ---- admin ----
+
+  @doc "Every user, newest first. Admin overview."
+  def list_all_users do
+    Repo.all(from u in User, order_by: [desc: u.inserted_at])
+  end
+
+  @doc "Marks a user's email confirmed without a token (admin verify)."
+  def verify_user(%User{} = user), do: user |> User.confirm_changeset() |> Repo.update()
+
+  @doc "Grants or revokes platform-admin access (console / admin use)."
+  def set_admin(%User{} = user, admin?) when is_boolean(admin?) do
+    user |> User.admin_changeset(admin?) |> Repo.update()
+  end
 end

--- a/lib/masthead/accounts/user.ex
+++ b/lib/masthead/accounts/user.ex
@@ -9,6 +9,7 @@ defmodule Masthead.Accounts.User do
     field :confirmed_at, :utc_datetime
     field :disabled_at, :utc_datetime
     field :wants_onboarding_emails, :boolean, default: true
+    field :admin, :boolean, default: false
 
     has_many :tokens, Masthead.Accounts.UserToken
 
@@ -20,6 +21,14 @@ defmodule Masthead.Accounts.User do
 
   @doc "Account is disabled (self-serve or auto-disabled)."
   def disabled?(%__MODULE__{disabled_at: at}), do: not is_nil(at)
+
+  @doc "Platform admin (can manage all users/sites/themes)."
+  def admin?(%__MODULE__{admin: admin}), do: admin == true
+
+  @doc "Grants or revokes platform-admin access."
+  def admin_changeset(user, admin?) when is_boolean(admin?) do
+    change(user, admin: admin?)
+  end
 
   @doc "Marks the email confirmed (no-op effect if already confirmed)."
   def confirm_changeset(user) do

--- a/lib/masthead/actions.ex
+++ b/lib/masthead/actions.ex
@@ -40,6 +40,25 @@ defmodule Masthead.Actions do
   end
 
   @doc """
+  Creates a custom, admin-authored action on `site` from free-text
+  `title` + `message`. Gets a unique generated key so it never collides
+  with the predefined types. Returns `{:ok, action}` or `{:error, changeset}`.
+  """
+  def create_custom_action(%Site{} = site, %{} = attrs) do
+    %Action{}
+    |> Action.changeset(%{
+      "key" => "custom_#{System.unique_integer([:positive])}",
+      "site_id" => site.id,
+      "status" => "pending",
+      "title" => attrs["title"],
+      "message" => attrs["message"],
+      "priority" => 100
+    })
+    |> Ecto.Changeset.validate_required([:title])
+    |> Repo.insert()
+  end
+
+  @doc """
   Onboarding milestone — called once a site gains its first post or page.
   Staggers in the "set description" nudge (unless a description is already
   set) so a brand-new, empty site isn't overwhelmed with it up front.
@@ -140,6 +159,7 @@ defmodule Masthead.Actions do
   end
 
   @doc "Render-time title for an action."
+  def title(%Action{title: title}) when is_binary(title) and title != "", do: title
   def title(%Action{key: key}), do: Definitions.title(key)
 
   @doc "Render-time button label for an action, or `nil`."

--- a/lib/masthead/actions/action.ex
+++ b/lib/masthead/actions/action.ex
@@ -21,6 +21,9 @@ defmodule Masthead.Actions.Action do
   schema "actions" do
     field :key, :string
     field :status, :string, default: "pending"
+    # Custom (admin-authored) actions store their own title; predefined ones
+    # leave this nil and derive the title from `key`.
+    field :title, :string
     field :message, :string
     field :priority, :integer, default: 0
     field :path, :string
@@ -33,7 +36,7 @@ defmodule Masthead.Actions.Action do
 
   def changeset(action, attrs) do
     action
-    |> cast(attrs, [:key, :status, :message, :priority, :path, :site_id])
+    |> cast(attrs, [:key, :status, :title, :message, :priority, :path, :site_id])
     |> validate_required([:key, :status, :site_id])
     |> validate_inclusion(:status, @statuses)
     |> assoc_constraint(:site)

--- a/lib/masthead/actions/definitions.ex
+++ b/lib/masthead/actions/definitions.ex
@@ -42,6 +42,9 @@ defmodule Masthead.Actions.Definitions do
   @doc "Returns the definition map for `key`, or `nil` if unknown."
   def get(key), do: Map.get(@definitions, key)
 
+  @doc "All defined action keys."
+  def keys, do: Map.keys(@definitions)
+
   @doc "Keys of action types that may trigger a one-off reminder email."
   def remindable_keys do
     for {key, %{remindable: true}} <- @definitions, do: key

--- a/lib/masthead/sites.ex
+++ b/lib/masthead/sites.ex
@@ -4,25 +4,33 @@ defmodule Masthead.Sites do
   alias Masthead.Sites.Site
 
   def list_sites_for_user(user_id) do
-    Repo.all(from s in Site, where: s.owner_id == ^user_id, order_by: s.name)
+    Repo.all(
+      from s in Site, where: s.owner_id == ^user_id and is_nil(s.deleted_at), order_by: s.name
+    )
   end
 
   def get_site!(id), do: Repo.get!(Site, id)
 
   def get_user_site!(user_id, id) do
-    Repo.one!(from s in Site, where: s.id == ^id and s.owner_id == ^user_id)
+    Repo.one!(
+      from s in Site, where: s.id == ^id and s.owner_id == ^user_id and is_nil(s.deleted_at)
+    )
   end
 
   def get_user_site_by_slug!(user_id, slug) do
-    Repo.one!(from s in Site, where: s.slug == ^slug and s.owner_id == ^user_id)
+    Repo.one!(
+      from s in Site, where: s.slug == ^slug and s.owner_id == ^user_id and is_nil(s.deleted_at)
+    )
   end
 
   @doc """
-  Public resolver used by the Subdomain plug. Disabled sites (the owning
-  account was disabled) resolve to `nil` so the request 404s.
+  Public resolver used by the Subdomain plug. Disabled or soft-deleted
+  sites resolve to `nil` so the request 404s.
   """
   def get_site_by_slug(slug) when is_binary(slug) do
-    Repo.one(from s in Site, where: s.slug == ^slug and is_nil(s.disabled_at))
+    Repo.one(
+      from s in Site, where: s.slug == ^slug and is_nil(s.disabled_at) and is_nil(s.deleted_at)
+    )
   end
 
   @doc """
@@ -38,7 +46,8 @@ defmodule Masthead.Sites do
         where:
           s.custom_domain == ^host and
             s.custom_domain_status == "active" and
-            is_nil(s.disabled_at)
+            is_nil(s.disabled_at) and
+            is_nil(s.deleted_at)
     )
   end
 
@@ -52,10 +61,41 @@ defmodule Masthead.Sites do
         where:
           s.custom_domain_status == "active" and
             not is_nil(s.custom_domain) and
-            is_nil(s.disabled_at),
+            is_nil(s.disabled_at) and
+            is_nil(s.deleted_at),
         select: s.custom_domain
     )
   end
+
+  # ---- admin ----
+
+  @doc "Every site (incl. disabled/soft-deleted), with owner preloaded."
+  def list_all_sites do
+    Repo.all(from s in Site, order_by: [asc: s.name], preload: [:owner])
+  end
+
+  @doc "Load any site by slug for an admin entering it. Excludes soft-deleted."
+  def get_site_for_admin_by_slug!(slug) when is_binary(slug) do
+    Repo.one!(from s in Site, where: s.slug == ^slug and is_nil(s.deleted_at))
+  end
+
+  defp set_site_timestamp(%Site{} = site, field, value) do
+    site |> Ecto.Changeset.change(%{field => value}) |> Repo.update()
+  end
+
+  @doc "Pauses a site (stops resolving). Reversible via `enable_site/1`."
+  def disable_site(%Site{} = site), do: set_site_timestamp(site, :disabled_at, truncated_now())
+
+  @doc "Un-pauses a site."
+  def enable_site(%Site{} = site), do: set_site_timestamp(site, :disabled_at, nil)
+
+  @doc "Soft-deletes a site (hidden from owner + public; retained for recovery)."
+  def soft_delete_site(%Site{} = site), do: set_site_timestamp(site, :deleted_at, truncated_now())
+
+  @doc "Restores a soft-deleted site."
+  def restore_site(%Site{} = site), do: set_site_timestamp(site, :deleted_at, nil)
+
+  defp truncated_now, do: DateTime.utc_now() |> DateTime.truncate(:second)
 
   @doc "Soft-disables every site owned by `user_id` (account-disable cascade)."
   def disable_sites_for_user(user_id) do

--- a/lib/masthead/sites/site.ex
+++ b/lib/masthead/sites/site.ex
@@ -2,7 +2,7 @@ defmodule Masthead.Sites.Site do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @reserved_slugs ~w(www api app dashboard login signup logout auth public assets static help docs sites new themes)
+  @reserved_slugs ~w(www api app admin dashboard login signup logout auth public assets static help docs sites new themes)
 
   schema "sites" do
     field :slug, :string
@@ -21,6 +21,9 @@ defmodule Masthead.Sites.Site do
     # (Masthead.Accounts.disable_user/1). Non-null => the site does not
     # resolve publicly (Subdomain plug 404s).
     field :disabled_at, :utc_datetime
+    # Admin soft-delete (distinct from `disabled_at`): hides the site from
+    # its owner and the public, but the row is retained for recovery.
+    field :deleted_at, :utc_datetime
     belongs_to :owner, Masthead.Accounts.User
     belongs_to :theme_ref, Masthead.Themes.Theme, foreign_key: :theme_id
     belongs_to :homepage_page, Masthead.Content.Page, foreign_key: :homepage_page_id

--- a/lib/masthead/themes.ex
+++ b/lib/masthead/themes.ex
@@ -12,7 +12,12 @@ defmodule Masthead.Themes do
 
   import Ecto.Query
   alias Masthead.Repo
+  alias Masthead.Storage
   alias Masthead.Themes.Theme
+
+  # The canonical files that make up a theme directory.
+  @theme_files ["manifest.json", "theme.css"] ++
+                 Enum.map(~w(layout index post page blog not_found), &"templates/#{&1}.liquid")
 
   @doc """
   List every theme visible to the given user:
@@ -92,4 +97,37 @@ defmodule Masthead.Themes do
 
   def delete_theme(%Theme{source: "uploaded"} = theme), do: Repo.delete(theme)
   def delete_theme(%Theme{source: "built_in"}), do: {:error, :built_in_protected}
+
+  # ---- admin ----
+
+  @doc "Every theme, with owner preloaded. Admin overview."
+  def list_all_themes do
+    Repo.all(from t in Theme, order_by: ^theme_order(), preload: [:owner])
+  end
+
+  @doc """
+  Reconstruct an uploaded theme's source files into an in-memory `.zip`.
+  Returns `{:ok, filename, zip_binary}` or `{:error, reason}`. Built-in
+  themes aren't downloadable (they live in the repo already).
+  """
+  def package_theme(%Theme{source: "built_in"}), do: {:error, :built_in_not_downloadable}
+
+  def package_theme(%Theme{source: "uploaded", storage_path: path} = theme) do
+    entries =
+      Enum.reduce_while(@theme_files, [], fn rel, acc ->
+        case Storage.read(Path.join(path, rel)) do
+          {:ok, bin} -> {:cont, [{String.to_charlist(rel), bin} | acc]}
+          {:error, reason} -> {:halt, {:error, {rel, reason}}}
+        end
+      end)
+
+    with entries when is_list(entries) <- entries,
+         filename = "#{theme.slug}-#{theme.version}.zip",
+         {:ok, {_name, zip}} <-
+           :zip.create(String.to_charlist(filename), Enum.reverse(entries), [:memory]) do
+      {:ok, filename, zip}
+    else
+      {:error, _} = err -> err
+    end
+  end
 end

--- a/lib/masthead_web/controllers/admin_controller.ex
+++ b/lib/masthead_web/controllers/admin_controller.ex
@@ -1,0 +1,20 @@
+defmodule MastheadWeb.AdminController do
+  use MastheadWeb, :controller
+
+  alias Masthead.Themes
+
+  @doc "Streams an uploaded theme's source files as a .zip download."
+  def download_theme(conn, %{"id" => id}) do
+    theme = Themes.get_theme!(id)
+
+    case Themes.package_theme(theme) do
+      {:ok, filename, zip} ->
+        send_download(conn, {:binary, zip}, filename: filename, content_type: "application/zip")
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "That theme can't be downloaded.")
+        |> redirect(to: ~p"/admin")
+    end
+  end
+end

--- a/lib/masthead_web/controllers/page_html/home.html.heex
+++ b/lib/masthead_web/controllers/page_html/home.html.heex
@@ -21,6 +21,13 @@
         </svg>
         <span>GitHub</span>
       </a>
+      <.link
+        :if={assigns[:current_user] && @current_user.admin}
+        navigate={~p"/admin"}
+        class="nav-link"
+      >
+        Admin
+      </.link>
       <%= if assigns[:current_user] do %>
         <.link navigate={~p"/sites"} class="btn btn-primary btn-sm">Open dashboard &rarr;</.link>
       <% else %>

--- a/lib/masthead_web/live/admin/admin_hooks.ex
+++ b/lib/masthead_web/live/admin/admin_hooks.ex
@@ -12,9 +12,14 @@ defmodule MastheadWeb.AdminLive.Hooks do
   def on_mount(:load_site, %{"site_slug" => slug}, _session, socket) do
     user = socket.assigns.current_user
 
-    case Sites.get_user_site_by_slug!(user.id, slug) do
-      site -> {:cont, assign(socket, :site, site)}
-    end
+    # Admins can enter any site at owner level; everyone else is scoped to
+    # the sites they own.
+    site =
+      if user.admin,
+        do: Sites.get_site_for_admin_by_slug!(slug),
+        else: Sites.get_user_site_by_slug!(user.id, slug)
+
+    {:cont, assign(socket, :site, site)}
   rescue
     Ecto.NoResultsError ->
       {:halt,

--- a/lib/masthead_web/live/admin/components.ex
+++ b/lib/masthead_web/live/admin/components.ex
@@ -86,6 +86,15 @@ defmodule MastheadWeb.AdminLive.Components do
             <.nav_link href={~p"/themes"} label="Themes" active={@active == :themes}>
               <.icon_palette />
             </.nav_link>
+
+            <.nav_link
+              :if={@current_user && @current_user.admin}
+              href={~p"/admin"}
+              label="Admin"
+              active={@active == :admin}
+            >
+              <.icon_shield />
+            </.nav_link>
           <% end %>
         </nav>
 
@@ -520,6 +529,25 @@ defmodule MastheadWeb.AdminLive.Components do
         stroke-linecap="round"
         stroke-linejoin="round"
         d="M9.53 16.122a3 3 0 0 0-5.78 1.128 2.25 2.25 0 0 1-2.4 2.245 4.5 4.5 0 0 0 8.4-2.245c0-.399-.078-.78-.22-1.128Zm0 0a15.998 15.998 0 0 0 3.388-1.62m-5.043-.025a15.994 15.994 0 0 1 1.622-3.395m3.42 3.42a15.995 15.995 0 0 0 4.764-4.648l3.876-5.814a1.151 1.151 0 0 0-1.597-1.597L14.146 6.32a15.996 15.996 0 0 0-4.649 4.763m3.42 3.42a6.776 6.776 0 0 0-3.42-3.42"
+      />
+    </svg>
+    """
+  end
+
+  defp icon_shield(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="icon"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
       />
     </svg>
     """

--- a/lib/masthead_web/live/admin/console.ex
+++ b/lib/masthead_web/live/admin/console.ex
@@ -1,0 +1,341 @@
+defmodule MastheadWeb.AdminLive.Console do
+  @moduledoc "Platform-admin overview: manage all users, sites, and themes."
+  use MastheadWeb, :live_view
+
+  import MastheadWeb.AdminLive.Components
+
+  alias Masthead.{Accounts, Actions, Sites, Themes}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(
+       page_title: "Admin",
+       tab: :users,
+       action_modal?: false,
+       action_site: nil
+     )
+     |> load_data()}
+  end
+
+  defp load_data(socket) do
+    assign(socket,
+      users: Accounts.list_all_users(),
+      sites: Sites.list_all_sites(),
+      themes: Themes.list_all_themes()
+    )
+  end
+
+  @impl true
+  def handle_event("switch_tab", %{"tab" => tab}, socket) do
+    {:noreply, assign(socket, tab: String.to_existing_atom(tab))}
+  end
+
+  # ---- users ----
+
+  def handle_event("verify_user", %{"id" => id}, socket) do
+    {:ok, _} = id |> Accounts.get_user!() |> Accounts.verify_user()
+    {:noreply, socket |> put_flash(:info, "User verified.") |> load_data()}
+  end
+
+  def handle_event("disable_user", %{"id" => id}, socket) do
+    {:ok, _} = id |> Accounts.get_user!() |> Accounts.disable_user()
+    {:noreply, socket |> put_flash(:info, "User disabled.") |> load_data()}
+  end
+
+  def handle_event("enable_user", %{"id" => id}, socket) do
+    {:ok, _} = id |> Accounts.get_user!() |> Accounts.enable_user()
+    {:noreply, socket |> put_flash(:info, "User re-enabled.") |> load_data()}
+  end
+
+  # ---- sites ----
+
+  def handle_event("disable_site", %{"id" => id}, socket) do
+    {:ok, _} = id |> Sites.get_site!() |> Sites.disable_site()
+    {:noreply, socket |> put_flash(:info, "Site disabled.") |> load_data()}
+  end
+
+  def handle_event("enable_site", %{"id" => id}, socket) do
+    {:ok, _} = id |> Sites.get_site!() |> Sites.enable_site()
+    {:noreply, socket |> put_flash(:info, "Site enabled.") |> load_data()}
+  end
+
+  def handle_event("delete_site", %{"id" => id}, socket) do
+    {:ok, _} = id |> Sites.get_site!() |> Sites.soft_delete_site()
+    {:noreply, socket |> put_flash(:info, "Site deleted (recoverable).") |> load_data()}
+  end
+
+  def handle_event("restore_site", %{"id" => id}, socket) do
+    {:ok, _} = id |> Sites.get_site!() |> Sites.restore_site()
+    {:noreply, socket |> put_flash(:info, "Site restored.") |> load_data()}
+  end
+
+  def handle_event("open_action_modal", %{"site_id" => id}, socket) do
+    {:noreply, assign(socket, action_modal?: true, action_site: Sites.get_site!(id))}
+  end
+
+  def handle_event("close_action_modal", _params, socket) do
+    {:noreply, assign(socket, action_modal?: false, action_site: nil)}
+  end
+
+  def handle_event("create_action", %{"title" => title} = params, socket) do
+    site = socket.assigns.action_site
+
+    case Actions.create_custom_action(site, %{"title" => title, "message" => params["message"]}) do
+      {:ok, _action} ->
+        {:noreply,
+         socket
+         |> assign(action_modal?: false, action_site: nil)
+         |> put_flash(:info, "Action added to #{site.name}.")}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "A title is required.")}
+    end
+  end
+
+  # ---- render ----
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.shell title="Admin" current_user={@current_user} flash={@flash} active={:admin}>
+      <div class="admin-tabs">
+        <button
+          :for={{id, label} <- [{:users, "Users"}, {:sites, "Sites"}, {:themes, "Themes"}]}
+          type="button"
+          phx-click="switch_tab"
+          phx-value-tab={id}
+          class={"admin-tab" <> if(@tab == id, do: " is-active", else: "")}
+        >
+          {label}
+        </button>
+      </div>
+
+      <div :if={@tab == :users} class="admin-table-wrap">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Status</th>
+              <th>Role</th>
+              <th>Joined</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={u <- @users}>
+              <td>{u.email}</td>
+              <td>
+                <span class={"pill " <> if(Accounts.User.confirmed?(u), do: "pill-ok", else: "pill-warn")}>
+                  {if Accounts.User.confirmed?(u), do: "verified", else: "unverified"}
+                </span>
+                <span :if={Accounts.User.disabled?(u)} class="pill pill-danger">disabled</span>
+              </td>
+              <td>{if u.admin, do: "admin", else: "—"}</td>
+              <td class="muted">{Calendar.strftime(u.inserted_at, "%b %-d, %Y")}</td>
+              <td class="admin-row-actions">
+                <button
+                  :if={not Accounts.User.confirmed?(u)}
+                  class="btn btn-sm"
+                  phx-click="verify_user"
+                  phx-value-id={u.id}
+                >
+                  Verify
+                </button>
+                <button
+                  :if={not Accounts.User.disabled?(u)}
+                  class="btn btn-sm"
+                  phx-click="disable_user"
+                  phx-value-id={u.id}
+                  data-confirm={"Disable #{u.email}? Their sites stop resolving."}
+                >
+                  Disable
+                </button>
+                <button
+                  :if={Accounts.User.disabled?(u)}
+                  class="btn btn-sm"
+                  phx-click="enable_user"
+                  phx-value-id={u.id}
+                >
+                  Enable
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div :if={@tab == :sites} class="admin-table-wrap">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Slug</th>
+              <th>Owner</th>
+              <th>Status</th>
+              <th>Add action</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={s <- @sites}>
+              <td>{s.name}</td>
+              <td class="muted">{s.slug}</td>
+              <td class="muted">{s.owner && s.owner.email}</td>
+              <td>
+                <span :if={not is_nil(s.deleted_at)} class="pill pill-danger">deleted</span>
+                <span
+                  :if={is_nil(s.deleted_at) and not is_nil(s.disabled_at)}
+                  class="pill pill-warn"
+                >
+                  disabled
+                </span>
+                <span :if={is_nil(s.deleted_at) and is_nil(s.disabled_at)} class="pill pill-ok">
+                  active
+                </span>
+              </td>
+              <td>
+                <button
+                  type="button"
+                  class="btn btn-sm"
+                  phx-click="open_action_modal"
+                  phx-value-site_id={s.id}
+                >
+                  + Action
+                </button>
+              </td>
+              <td class="admin-row-actions">
+                <.link :if={is_nil(s.deleted_at)} navigate={~p"/#{s.slug}"} class="btn btn-sm">
+                  Enter
+                </.link>
+                <button
+                  :if={is_nil(s.disabled_at) and is_nil(s.deleted_at)}
+                  class="btn btn-sm"
+                  phx-click="disable_site"
+                  phx-value-id={s.id}
+                >
+                  Disable
+                </button>
+                <button
+                  :if={not is_nil(s.disabled_at) and is_nil(s.deleted_at)}
+                  class="btn btn-sm"
+                  phx-click="enable_site"
+                  phx-value-id={s.id}
+                >
+                  Enable
+                </button>
+                <button
+                  :if={is_nil(s.deleted_at)}
+                  class="btn btn-sm btn-danger"
+                  phx-click="delete_site"
+                  phx-value-id={s.id}
+                  data-confirm={"Delete #{s.name}? It's recoverable from here."}
+                >
+                  Delete
+                </button>
+                <button
+                  :if={not is_nil(s.deleted_at)}
+                  class="btn btn-sm"
+                  phx-click="restore_site"
+                  phx-value-id={s.id}
+                >
+                  Restore
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div :if={@tab == :themes} class="admin-table-wrap">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Slug</th>
+              <th>Version</th>
+              <th>Source</th>
+              <th>Owner</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={t <- @themes}>
+              <td>{t.name}</td>
+              <td class="muted">{t.slug}</td>
+              <td class="muted">{t.version}</td>
+              <td>{t.source}</td>
+              <td class="muted">{(t.owner && t.owner.email) || "—"}</td>
+              <td class="admin-row-actions">
+                <a
+                  :if={t.source == "uploaded"}
+                  href={~p"/admin/themes/#{t.id}/download"}
+                  class="btn btn-sm"
+                >
+                  Download
+                </a>
+                <button
+                  :if={t.source != "uploaded"}
+                  type="button"
+                  class="btn btn-sm"
+                  disabled
+                  title="Built-in themes live in the repo and can't be downloaded."
+                >
+                  Download
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div
+        :if={@action_modal?}
+        class="dialog-backdrop"
+        phx-window-keydown="close_action_modal"
+        phx-key="Escape"
+      >
+        <button
+          type="button"
+          phx-click="close_action_modal"
+          class="dialog-close-overlay"
+          aria-label="Close"
+          tabindex="-1"
+        >
+        </button>
+        <div class="dialog">
+          <header class="dialog-header">
+            <h2>Add action{if @action_site, do: " — #{@action_site.name}"}</h2>
+            <button
+              type="button"
+              phx-click="close_action_modal"
+              class="dialog-close"
+              aria-label="Close"
+            >
+              &times;
+            </button>
+          </header>
+
+          <form phx-submit="create_action" class="dialog-form">
+            <label>
+              Title <input type="text" name="title" autocomplete="off" required />
+            </label>
+            <label>
+              Message <textarea
+                name="message"
+                rows="3"
+                placeholder="Optional detail shown under the title."
+              ></textarea>
+              <small>Appears as a pending action in the owner's checklist.</small>
+            </label>
+            <div class="dialog-footer">
+              <button type="button" phx-click="close_action_modal" class="btn">Cancel</button>
+              <button type="submit" class="btn btn-primary">Add action</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </.shell>
+    """
+  end
+end

--- a/lib/masthead_web/live/admin/site_settings.ex
+++ b/lib/masthead_web/live/admin/site_settings.ex
@@ -23,6 +23,7 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
        picker_open?: false,
        picker_view: :grid,
        picker_token: nil,
+       open_token_group: nil,
        selected_theme: pick_theme(themes, current_theme_id(changeset, site))
      )
      |> allow_upload(:picker_image,
@@ -34,6 +35,14 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
   end
 
   @impl true
+  # Track the single open token-category accordion server-side, so a form
+  # re-render (phx-change while typing) doesn't reset the native `<details>`
+  # state. Only one category is open at a time; clicking the open one closes it.
+  def handle_event("toggle_token_group", %{"group" => group}, socket) do
+    open = if socket.assigns.open_token_group == group, do: nil, else: group
+    {:noreply, assign(socket, open_token_group: open)}
+  end
+
   def handle_event("validate", %{"site" => params}, socket) do
     changeset =
       socket.assigns.site
@@ -440,8 +449,18 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
                 </div>
               <% {:grouped, groups} -> %>
                 <div class="token-groups">
-                  <details :for={{category, tokens} <- groups} class="token-group">
-                    <summary class="token-group-summary">{category}</summary>
+                  <details
+                    :for={{category, tokens} <- groups}
+                    class="token-group"
+                    open={@open_token_group == category}
+                  >
+                    <summary
+                      class="token-group-summary"
+                      phx-click="toggle_token_group"
+                      phx-value-group={category}
+                    >
+                      {category}
+                    </summary>
                     <div class="settings-fields">
                       <.token_field
                         :for={tok <- tokens}

--- a/lib/masthead_web/router.ex
+++ b/lib/masthead_web/router.ex
@@ -1,7 +1,8 @@
 defmodule MastheadWeb.Router do
   use MastheadWeb, :router
 
-  import MastheadWeb.UserAuth, only: [fetch_current_user: 2, require_authenticated_user: 2]
+  import MastheadWeb.UserAuth,
+    only: [fetch_current_user: 2, require_authenticated_user: 2, require_admin_user: 2]
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -11,6 +12,10 @@ defmodule MastheadWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :fetch_current_user
+  end
+
+  pipeline :require_admin do
+    plug :require_admin_user
   end
 
   scope "/", MastheadWeb do
@@ -44,12 +49,26 @@ defmodule MastheadWeb.Router do
     post "/:provider/callback", AuthController, :callback
   end
 
+  # Admin controller routes (platform admins only).
+  scope "/admin", MastheadWeb do
+    pipe_through [:browser, :require_authenticated_user, :require_admin]
+
+    get "/themes/:id/download", AdminController, :download_theme
+  end
+
   scope "/", MastheadWeb do
     pipe_through [:browser, :require_authenticated_user]
 
     get "/account", AccountController, :show
     post "/account/password", AccountController, :update_password
     post "/account/disable", AccountController, :disable
+
+    # Admin overview — defined before the `/:site_slug` catch-all so "admin"
+    # isn't resolved as a site slug.
+    live_session :admin,
+      on_mount: [{MastheadWeb.UserAuth, :require_admin}] do
+      live "/admin", AdminLive.Console, :index
+    end
 
     live_session :authenticated,
       on_mount: [{MastheadWeb.UserAuth, :require_authenticated}] do

--- a/lib/masthead_web/user_auth.ex
+++ b/lib/masthead_web/user_auth.ex
@@ -49,6 +49,36 @@ defmodule MastheadWeb.UserAuth do
     end
   end
 
+  def require_admin_user(conn, _opts) do
+    user = conn.assigns[:current_user]
+
+    if user && user.admin do
+      conn
+    else
+      conn
+      |> Phoenix.Controller.put_flash(:error, "You don't have access to that page.")
+      |> redirect(to: "/")
+      |> halt()
+    end
+  end
+
+  def on_mount(:require_admin, _params, session, socket) do
+    user =
+      case session["user_id"] do
+        nil -> nil
+        id -> safe_get_user(id)
+      end
+
+    if user && user.admin do
+      {:cont, Phoenix.Component.assign(socket, :current_user, user)}
+    else
+      {:halt,
+       socket
+       |> Phoenix.LiveView.put_flash(:error, "You don't have access to that page.")
+       |> Phoenix.LiveView.redirect(to: "/")}
+    end
+  end
+
   def on_mount(:current_user, _params, session, socket) do
     user =
       case session["user_id"] do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.3.0",
+      version: "2.4.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260602160000_add_admin_and_site_soft_delete.exs
+++ b/priv/repo/migrations/20260602160000_add_admin_and_site_soft_delete.exs
@@ -1,0 +1,18 @@
+defmodule Masthead.Repo.Migrations.AddAdminAndSiteSoftDelete do
+  use Ecto.Migration
+
+  def change do
+    # Platform admins — can manage all users/sites/themes from the admin
+    # overview. Granted via seeds/console (no self-serve promotion).
+    alter table(:users) do
+      add :admin, :boolean, null: false, default: false
+    end
+
+    # Soft-delete for sites: distinct from `disabled_at` (a reversible
+    # pause). A soft-deleted site is hidden from its owner and the public,
+    # but retained for admin recovery.
+    alter table(:sites) do
+      add :deleted_at, :utc_datetime
+    end
+  end
+end

--- a/priv/repo/migrations/20260602170000_add_action_title.exs
+++ b/priv/repo/migrations/20260602170000_add_action_title.exs
@@ -1,0 +1,11 @@
+defmodule Masthead.Repo.Migrations.AddActionTitle do
+  use Ecto.Migration
+
+  # Custom (admin-authored) actions carry their own title text. Predefined
+  # actions leave this null and derive their title from the key.
+  def change do
+    alter table(:actions) do
+      add :title, :string
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -2,19 +2,21 @@ alias Masthead.Accounts
 alias Masthead.Sites
 alias Masthead.Content
 
-# Demo user
+# Demo user (a platform admin, so the admin overview is reachable in dev)
 {:ok, user} =
   case Accounts.get_user_by_email("admin@example.com") do
     nil -> Accounts.register_user(%{"email" => "admin@example.com", "password" => "password1234"})
     existing -> {:ok, existing}
   end
 
-# Demo site
+{:ok, user} = Accounts.set_admin(user, true)
+
+# Demo site ("admin" is a reserved slug now — it routes to the admin overview)
 {:ok, site} =
-  case Sites.get_site_by_slug("admin") do
+  case Sites.get_site_by_slug("demo") do
     nil ->
       Sites.create_site(%{
-        "slug" => "admin",
+        "slug" => "demo",
         "name" => "Example Site",
         "title" => "Example Site",
         "description" =>
@@ -118,7 +120,7 @@ end
 IO.puts("""
 
 Seeded:
-  user:  admin@example.com / password1234
-  site:  http://admin.lvh.me:4000
-  admin: http://localhost:4000/sites
+  user:  admin@example.com / password1234 (platform admin)
+  site:  http://demo.lvh.me:4000
+  admin: http://localhost:4000/admin
 """)

--- a/test/masthead/sites_soft_delete_test.exs
+++ b/test/masthead/sites_soft_delete_test.exs
@@ -1,0 +1,43 @@
+defmodule Masthead.SitesSoftDeleteTest do
+  use Masthead.DataCase
+
+  alias Masthead.{Accounts, Sites}
+
+  setup do
+    {:ok, user} =
+      Accounts.register_user(%{
+        "email" => "sd-#{System.unique_integer([:positive])}@example.com",
+        "password" => "password1234"
+      })
+
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "sd#{System.unique_integer([:positive])}",
+        "name" => "SD Site",
+        "owner_id" => user.id
+      })
+
+    %{user: user, site: site}
+  end
+
+  test "a soft-deleted site is hidden from its owner and the public", %{user: user, site: site} do
+    assert Enum.any?(Sites.list_sites_for_user(user.id), &(&1.id == site.id))
+    assert Sites.get_site_by_slug(site.slug)
+
+    {:ok, _} = Sites.soft_delete_site(site)
+
+    refute Enum.any?(Sites.list_sites_for_user(user.id), &(&1.id == site.id))
+    refute Sites.get_site_by_slug(site.slug)
+
+    # Restoring brings it back.
+    {:ok, _} = Sites.restore_site(Sites.get_site!(site.id))
+    assert Sites.get_site_by_slug(site.slug)
+  end
+
+  test "a disabled site stays visible to its owner but stops resolving", %{user: user, site: site} do
+    {:ok, _} = Sites.disable_site(site)
+
+    assert Enum.any?(Sites.list_sites_for_user(user.id), &(&1.id == site.id))
+    refute Sites.get_site_by_slug(site.slug)
+  end
+end

--- a/test/masthead_web/admin_console_live_test.exs
+++ b/test/masthead_web/admin_console_live_test.exs
@@ -1,0 +1,169 @@
+defmodule MastheadWeb.AdminConsoleLiveTest do
+  use MastheadWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Masthead.{Accounts, Sites}
+
+  setup do
+    Masthead.Themes.Seed.run()
+
+    {:ok, admin} =
+      Accounts.register_user(%{
+        "email" => "admin-#{System.unique_integer([:positive])}@example.com",
+        "password" => "password1234"
+      })
+
+    {:ok, admin} = Accounts.set_admin(admin, true)
+
+    {:ok, member} =
+      Accounts.register_user(%{
+        "email" => "member-#{System.unique_integer([:positive])}@example.com",
+        "password" => "password1234"
+      })
+
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "mem#{System.unique_integer([:positive])}",
+        "name" => "Member Site",
+        "owner_id" => member.id
+      })
+
+    %{admin: admin, member: member, site: site, conn: conn_for(admin)}
+  end
+
+  defp conn_for(user) do
+    build_conn()
+    |> Plug.Test.init_test_session(%{})
+    |> Plug.Conn.put_session(:user_id, user.id)
+  end
+
+  test "non-admins are redirected away from /admin", %{member: member} do
+    assert {:error, {:redirect, %{to: "/"}}} = live(conn_for(member), ~p"/admin")
+  end
+
+  test "admin sees all users, sites and themes", %{conn: conn, member: member, site: site} do
+    {:ok, lv, html} = live(conn, ~p"/admin")
+
+    # Users tab (default).
+    assert html =~ member.email
+
+    # Sites tab.
+    html = lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+    assert html =~ site.name
+    assert html =~ member.email
+
+    # Themes tab.
+    html = lv |> element(~s(button[phx-value-tab="themes"])) |> render_click()
+    assert html =~ "Tailwind"
+  end
+
+  test "admin can verify an unverified user", %{conn: conn, member: member} do
+    refute Accounts.User.confirmed?(member)
+    {:ok, lv, _} = live(conn, ~p"/admin")
+
+    lv
+    |> element(~s(button[phx-click="verify_user"][phx-value-id="#{member.id}"]))
+    |> render_click()
+
+    assert Accounts.get_user!(member.id) |> Accounts.User.confirmed?()
+  end
+
+  test "admin can disable and re-enable a site", %{conn: conn, site: site} do
+    {:ok, lv, _} = live(conn, ~p"/admin")
+    lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+
+    lv
+    |> element(~s(button[phx-click="disable_site"][phx-value-id="#{site.id}"]))
+    |> render_click()
+
+    assert Sites.get_site!(site.id).disabled_at
+
+    lv
+    |> element(~s(button[phx-click="enable_site"][phx-value-id="#{site.id}"]))
+    |> render_click()
+
+    refute Sites.get_site!(site.id).disabled_at
+  end
+
+  test "admin can soft-delete and restore a site", %{conn: conn, site: site} do
+    {:ok, lv, _} = live(conn, ~p"/admin")
+    lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+
+    lv
+    |> element(~s(button[phx-click="delete_site"][phx-value-id="#{site.id}"]))
+    |> render_click()
+
+    assert Sites.get_site!(site.id).deleted_at
+
+    lv
+    |> element(~s(button[phx-click="restore_site"][phx-value-id="#{site.id}"]))
+    |> render_click()
+
+    refute Sites.get_site!(site.id).deleted_at
+  end
+
+  test "admin can add a custom action to a site via the modal", %{conn: conn, site: site} do
+    {:ok, lv, _} = live(conn, ~p"/admin")
+    lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+
+    lv
+    |> element(~s(button[phx-click="open_action_modal"][phx-value-site_id="#{site.id}"]))
+    |> render_click()
+
+    lv
+    |> form(~s(form[phx-submit="create_action"]), %{
+      title: "Please add a logo",
+      message: "Your header looks bare."
+    })
+    |> render_submit()
+
+    action = Enum.find(Masthead.Actions.list_pending(site), &(&1.title == "Please add a logo"))
+    assert action
+    assert action.message == "Your header looks bare."
+  end
+
+  test "admin can enter another person's site at owner level", %{conn: conn, site: site} do
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}")
+    # The site dashboard loads (admin bypassed the ownership check).
+    assert html =~ site.name
+  end
+
+  test "admin can download an uploaded theme as a zip", %{conn: conn, member: member} do
+    slug = "dl#{System.unique_integer([:positive])}"
+    {:ok, theme} = install_uploaded_theme(slug, member.id)
+
+    conn = get(conn, ~p"/admin/themes/#{theme.id}/download")
+
+    assert response_content_type(conn, :zip) =~ "zip"
+    assert get_resp_header(conn, "content-disposition") |> hd() =~ "#{slug}-1.0.0.zip"
+    # The body is a real zip (PK magic bytes).
+    assert binary_part(conn.resp_body, 0, 2) == "PK"
+  end
+
+  defp install_uploaded_theme(slug, owner_id) do
+    files = %{
+      "manifest.json" =>
+        Jason.encode!(%{
+          "name" => "DL #{slug}",
+          "slug" => slug,
+          "version" => "1.0.0",
+          "tokens" => []
+        }),
+      "templates/layout.liquid" => "<html><body>{{ content }}</body></html>",
+      "templates/index.liquid" => "<h1>{{ site.name }}</h1>",
+      "templates/post.liquid" => "<article>{{ body_html }}</article>",
+      "templates/page.liquid" => "<article>{{ body_html }}</article>",
+      "templates/blog.liquid" => "<h1>{{ page.title }}</h1>",
+      "templates/not_found.liquid" => "<h1>Not found</h1>",
+      "theme.css" => "body{}"
+    }
+
+    tmp = Path.join(System.tmp_dir!(), "dl-#{System.unique_integer([:positive])}.zip")
+    entries = Enum.map(files, fn {n, b} -> {String.to_charlist(n), b} end)
+    {:ok, _} = :zip.create(String.to_charlist(tmp), entries)
+    result = Masthead.Themes.Package.install(tmp, owner_id)
+    File.rm(tmp)
+    result
+  end
+end

--- a/test/masthead_web/site_settings_live_test.exs
+++ b/test/masthead_web/site_settings_live_test.exs
@@ -48,10 +48,34 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
     {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/settings")
 
     assert html =~ "token-group-summary"
-    assert html =~ "Header</summary>"
-    assert html =~ "Footer</summary>"
+    assert html =~ ~s(phx-value-group="Header")
+    assert html =~ ~s(phx-value-group="Footer")
     # logo/favicon/accent/cta have no category → grouped under General.
-    assert html =~ "General</summary>"
+    assert html =~ ~s(phx-value-group="General")
+  end
+
+  test "an opened category stays open across a form change, and only one opens at a time", %{
+    conn: conn,
+    site: site
+  } do
+    tailwind = Themes.get_built_in_by_slug("tailwind")
+    {:ok, site} = Sites.update_settings(site, %{"theme_id" => tailwind.id})
+    {:ok, lv, _} = live(conn, ~p"/#{site.slug}/settings")
+
+    open_header = ~r/<details[^>]*\bopen\b[^>]*>\s*<summary[^>]*phx-value-group="Header"/
+
+    # Open the Header group.
+    html = lv |> element(~s(summary[phx-value-group="Header"])) |> render_click()
+    assert html =~ open_header
+
+    # A form change (what previously closed it) keeps it open.
+    html = lv |> form("#site-settings-form", site: %{name: "Renamed"}) |> render_change()
+    assert html =~ open_header
+
+    # Opening Footer closes Header (single-open accordion).
+    html = lv |> element(~s(summary[phx-value-group="Footer"])) |> render_click()
+    refute html =~ open_header
+    assert html =~ ~r/<details[^>]*\bopen\b[^>]*>\s*<summary[^>]*phx-value-group="Footer"/
   end
 
   test "a file token renders a picker that lists the site's uploads in a modal", %{


### PR DESCRIPTION
Platform-admin overview at /admin (admin-only): tabbed tables of all users, sites, and themes, using the shared platform table style.

- Users: verify, disable/enable.
- Sites: enter any site at owner level (relaxed :load_site hook), disable/enable, soft-delete (recoverable) / restore, and a modal to author a custom action (free-text title + message).
- Themes: download uploaded themes as a reconstructed .zip; the button shows disabled for built-ins.

Foundations: users.admin boolean (seed admin@example.com; console otherwise), sites.deleted_at soft-delete (distinct from disabled_at; excluded from owner/public/custom-domain queries), actions.title for custom actions, "admin" reserved site slug (demo seed → "demo").

Also fixes the theme-settings token accordions: open state is tracked server-side so typing no longer collapses them, and only one category is open at a time.