### PR TITLE
fix: move site-settings danger zone inside the form

### DIFF
--- a/lib/masthead/themes.ex
+++ b/lib/masthead/themes.ex
@@ -95,8 +95,43 @@ defmodule Masthead.Themes do
     theme |> Theme.upload_changeset(attrs) |> Repo.update()
   end
 
-  def delete_theme(%Theme{source: "uploaded"} = theme), do: Repo.delete(theme)
+  @doc """
+  Delete an uploaded theme.
+
+  Built-ins are protected. A theme that is still referenced by one or more
+  sites can't be deleted (the `sites.theme_id` foreign key forbids it):
+  rather than letting the DB raise an `Ecto.ConstraintError`, we look up
+  the referencing sites first and return `{:error, {:in_use, sites}}`,
+  where `sites` is a list of `{name, deleted_at}` tuples so the caller can
+  tell the user exactly which site is holding the theme. The delete itself
+  also carries a `foreign_key_constraint` as a safety net against the race
+  where a site adopts the theme between the check and the delete.
+  """
   def delete_theme(%Theme{source: "built_in"}), do: {:error, :built_in_protected}
+
+  def delete_theme(%Theme{source: "uploaded"} = theme) do
+    case sites_using_theme(theme.id) do
+      [] ->
+        theme
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.foreign_key_constraint(:id, name: "sites_theme_id_fkey")
+        |> Repo.delete()
+
+      sites ->
+        {:error, {:in_use, sites}}
+    end
+  end
+
+  # Sites referencing the theme, including soft-deleted ones — a soft-deleted
+  # row still holds the foreign key, so it would block the delete too.
+  defp sites_using_theme(theme_id) do
+    Repo.all(
+      from s in Masthead.Sites.Site,
+        where: s.theme_id == ^theme_id,
+        order_by: [asc: s.name],
+        select: {s.name, s.deleted_at}
+    )
+  end
 
   # ---- admin ----
 

--- a/lib/masthead_web/live/admin/site_settings.ex
+++ b/lib/masthead_web/live/admin/site_settings.ex
@@ -531,6 +531,30 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
             </div>
           </div>
 
+          <div class="settings-section danger-zone">
+            <header class="settings-section-head">
+              <h2>Danger zone</h2>
+              <p>Permanently remove this site from your account.</p>
+            </header>
+            <div class="danger-row">
+              <div>
+                <strong>Delete this site</strong>
+                <p class="muted">
+                  Takes <code>{@site.slug}</code> offline and removes it from your sites.
+                  The data is retained for recovery — contact support if you delete it by mistake.
+                </p>
+              </div>
+              <button
+                type="button"
+                phx-click="delete_site"
+                class="btn btn-danger"
+                data-confirm={"Delete #{@site.name}? It will go offline immediately and disappear from your sites."}
+              >
+                Delete site
+              </button>
+            </div>
+          </div>
+
           <div class="wizard-footer">
             <.link navigate={~p"/#{@site.slug}"} class="btn">Cancel</.link>
             <button type="submit" class="btn btn-primary" data-shortcut="save">
@@ -538,30 +562,6 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
             </button>
           </div>
         </.form>
-
-        <div class="settings-section danger-zone">
-          <header class="settings-section-head">
-            <h2>Danger zone</h2>
-            <p>Permanently remove this site from your account.</p>
-          </header>
-          <div class="danger-row">
-            <div>
-              <strong>Delete this site</strong>
-              <p class="muted">
-                Takes <code>{@site.slug}</code> offline and removes it from your sites.
-                The data is retained for recovery — contact support if you delete it by mistake.
-              </p>
-            </div>
-            <button
-              type="button"
-              phx-click="delete_site"
-              class="btn btn-danger"
-              data-confirm={"Delete #{@site.name}? It will go offline immediately and disappear from your sites."}
-            >
-              Delete site
-            </button>
-          </div>
-        </div>
       </div>
 
       <div

--- a/lib/masthead_web/live/admin/theme_library.ex
+++ b/lib/masthead_web/live/admin/theme_library.ex
@@ -92,10 +92,28 @@ defmodule MastheadWeb.AdminLive.ThemeLibrary do
              |> assign(themes: themes_for(socket))
              |> put_flash(:info, "Theme deleted.")}
 
+          {:error, {:in_use, sites}} ->
+            {:noreply, put_flash(socket, :error, theme_in_use_message(sites))}
+
           {:error, _} ->
             {:noreply, put_flash(socket, :error, "Could not delete theme.")}
         end
     end
+  end
+
+  # Build a flash naming the sites that still reference a theme. Soft-deleted
+  # sites still hold the foreign key, so they're flagged as "(deleted)".
+  defp theme_in_use_message(sites) do
+    names =
+      Enum.map_join(sites, ", ", fn
+        {name, nil} -> name
+        {name, _deleted_at} -> "#{name} (deleted)"
+      end)
+
+    site_word = if length(sites) == 1, do: "site", else: "sites"
+
+    "Can't delete this theme — it's still in use by #{length(sites)} #{site_word}: " <>
+      "#{names}. Switch #{if length(sites) == 1, do: "it", else: "them"} to another theme first."
   end
 
   defp close_modal(socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.5.1",
+      version: "2.5.2",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/masthead/themes/delete_theme_test.exs
+++ b/test/masthead/themes/delete_theme_test.exs
@@ -1,0 +1,60 @@
+defmodule Masthead.Themes.DeleteThemeTest do
+  use Masthead.DataCase
+
+  alias Masthead.{Accounts, Sites, Themes}
+
+  setup do
+    {:ok, user} =
+      Accounts.register_user(%{
+        "email" => "del-theme-#{System.unique_integer([:positive])}@example.com",
+        "password" => "password1234"
+      })
+
+    {:ok, theme} =
+      Themes.create_upload(%{
+        slug: "ut#{System.unique_integer([:positive])}",
+        name: "Uploaded Theme",
+        version: "1.0.0",
+        storage_path: "themes/uploaded/1.0.0",
+        owner_id: user.id
+      })
+
+    %{user: user, theme: theme}
+  end
+
+  test "deletes an uploaded theme that no site uses", %{theme: theme} do
+    assert {:ok, _} = Themes.delete_theme(theme)
+    refute Themes.get_theme(theme.id)
+  end
+
+  test "refuses to delete a theme in use and names the site", %{user: user, theme: theme} do
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "uses#{System.unique_integer([:positive])}",
+        "name" => "Live Site",
+        "owner_id" => user.id,
+        "theme_id" => theme.id
+      })
+
+    assert {:error, {:in_use, sites}} = Themes.delete_theme(theme)
+    assert {site.name, nil} in sites
+    # The theme is untouched.
+    assert Themes.get_theme(theme.id)
+  end
+
+  test "a soft-deleted site still blocks deletion and is flagged", %{user: user, theme: theme} do
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "uses#{System.unique_integer([:positive])}",
+        "name" => "Gone Site",
+        "owner_id" => user.id,
+        "theme_id" => theme.id
+      })
+
+    {:ok, _} = Sites.soft_delete_site(site)
+
+    assert {:error, {:in_use, [{name, deleted_at}]}} = Themes.delete_theme(theme)
+    assert name == site.name
+    refute is_nil(deleted_at)
+  end
+end


### PR DESCRIPTION
The Delete-site danger zone rendered as a sibling outside the settings <form>, below the Save/Cancel footer — so the destructive action sat beneath the form's primary actions and looked detached. Move it inside the form as a normal settings-section, after Custom domain and above the wizard-footer, matching the Custom domain section's placement. The delete button stays type="button" with its own phx-click, so it still doesn't submit the form.