### PR TITLE
fix: don't let soft-deleted sites permanently block theme deletion

### DIFF
--- a/lib/masthead/themes.ex
+++ b/lib/masthead/themes.ex
@@ -98,39 +98,64 @@ defmodule Masthead.Themes do
   @doc """
   Delete an uploaded theme.
 
-  Built-ins are protected. A theme that is still referenced by one or more
-  sites can't be deleted (the `sites.theme_id` foreign key forbids it):
-  rather than letting the DB raise an `Ecto.ConstraintError`, we look up
-  the referencing sites first and return `{:error, {:in_use, sites}}`,
-  where `sites` is a list of `{name, deleted_at}` tuples so the caller can
-  tell the user exactly which site is holding the theme. The delete itself
-  also carries a `foreign_key_constraint` as a safety net against the race
-  where a site adopts the theme between the check and the delete.
+  Built-ins are protected. A theme still referenced by a *live* site can't
+  be deleted (the `sites.theme_id` foreign key forbids it): rather than
+  letting the DB raise an `Ecto.ConstraintError`, we look those sites up
+  first and return `{:error, {:in_use, names}}` so the caller can name
+  them. A *disabled* site still counts — its owner can re-enable it.
+
+  Soft-deleted sites are different: they render nothing, but their row
+  still holds the foreign key, so they would otherwise pin the theme
+  forever. We detach them onto the built-in `default` theme before
+  deleting, so they no longer block (they'd come back on `default` if ever
+  restored). The delete also carries a `foreign_key_constraint` as a
+  safety net against a site adopting the theme mid-operation.
   """
   def delete_theme(%Theme{source: "built_in"}), do: {:error, :built_in_protected}
 
   def delete_theme(%Theme{source: "uploaded"} = theme) do
-    case sites_using_theme(theme.id) do
+    case live_sites_using_theme(theme.id) do
       [] ->
+        detach_deleted_sites(theme.id)
+
         theme
         |> Ecto.Changeset.change()
         |> Ecto.Changeset.foreign_key_constraint(:id, name: "sites_theme_id_fkey")
         |> Repo.delete()
 
-      sites ->
-        {:error, {:in_use, sites}}
+      names ->
+        {:error, {:in_use, names}}
     end
   end
 
-  # Sites referencing the theme, including soft-deleted ones — a soft-deleted
-  # row still holds the foreign key, so it would block the delete too.
-  defp sites_using_theme(theme_id) do
+  # Names of non-deleted sites referencing the theme. Only `deleted_at`
+  # excludes a site; a disabled site can be re-enabled, so it still blocks.
+  defp live_sites_using_theme(theme_id) do
     Repo.all(
       from s in Masthead.Sites.Site,
-        where: s.theme_id == ^theme_id,
+        where: s.theme_id == ^theme_id and is_nil(s.deleted_at),
         order_by: [asc: s.name],
-        select: {s.name, s.deleted_at}
+        select: s.name
     )
+  end
+
+  # Re-point any soft-deleted sites off the doomed theme and onto `default`,
+  # so the foreign key no longer blocks its deletion.
+  defp detach_deleted_sites(theme_id) do
+    case get_built_in_by_slug("default") do
+      %Theme{id: default_id} ->
+        Repo.update_all(
+          from(s in Masthead.Sites.Site,
+            where: s.theme_id == ^theme_id and not is_nil(s.deleted_at)
+          ),
+          set: [theme_id: default_id]
+        )
+
+        :ok
+
+      nil ->
+        :ok
+    end
   end
 
   # ---- admin ----

--- a/lib/masthead_web/live/admin/theme_library.ex
+++ b/lib/masthead_web/live/admin/theme_library.ex
@@ -92,8 +92,8 @@ defmodule MastheadWeb.AdminLive.ThemeLibrary do
              |> assign(themes: themes_for(socket))
              |> put_flash(:info, "Theme deleted.")}
 
-          {:error, {:in_use, sites}} ->
-            {:noreply, put_flash(socket, :error, theme_in_use_message(sites))}
+          {:error, {:in_use, names}} ->
+            {:noreply, put_flash(socket, :error, theme_in_use_message(names))}
 
           {:error, _} ->
             {:noreply, put_flash(socket, :error, "Could not delete theme.")}
@@ -101,19 +101,13 @@ defmodule MastheadWeb.AdminLive.ThemeLibrary do
     end
   end
 
-  # Build a flash naming the sites that still reference a theme. Soft-deleted
-  # sites still hold the foreign key, so they're flagged as "(deleted)".
-  defp theme_in_use_message(sites) do
-    names =
-      Enum.map_join(sites, ", ", fn
-        {name, nil} -> name
-        {name, _deleted_at} -> "#{name} (deleted)"
-      end)
+  # Build a flash naming the live sites that still reference a theme.
+  defp theme_in_use_message(names) do
+    count = length(names)
+    site_word = if count == 1, do: "site", else: "sites"
 
-    site_word = if length(sites) == 1, do: "site", else: "sites"
-
-    "Can't delete this theme — it's still in use by #{length(sites)} #{site_word}: " <>
-      "#{names}. Switch #{if length(sites) == 1, do: "it", else: "them"} to another theme first."
+    "Can't delete this theme — it's still in use by #{count} #{site_word}: " <>
+      "#{Enum.join(names, ", ")}. Switch #{if count == 1, do: "it", else: "them"} to another theme first."
   end
 
   defp close_modal(socket) do

--- a/test/masthead/themes/delete_theme_test.exs
+++ b/test/masthead/themes/delete_theme_test.exs
@@ -4,6 +4,10 @@ defmodule Masthead.Themes.DeleteThemeTest do
   alias Masthead.{Accounts, Sites, Themes}
 
   setup do
+    # Built-ins (notably "default") must exist — soft-deleted sites are
+    # detached onto the default theme when their theme is deleted.
+    Themes.Seed.run()
+
     {:ok, user} =
       Accounts.register_user(%{
         "email" => "del-theme-#{System.unique_integer([:positive])}@example.com",
@@ -22,39 +26,50 @@ defmodule Masthead.Themes.DeleteThemeTest do
     %{user: user, theme: theme}
   end
 
+  defp site_using(user, theme, name) do
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "uses#{System.unique_integer([:positive])}",
+        "name" => name,
+        "owner_id" => user.id,
+        "theme_id" => theme.id
+      })
+
+    site
+  end
+
   test "deletes an uploaded theme that no site uses", %{theme: theme} do
     assert {:ok, _} = Themes.delete_theme(theme)
     refute Themes.get_theme(theme.id)
   end
 
-  test "refuses to delete a theme in use and names the site", %{user: user, theme: theme} do
-    {:ok, site} =
-      Sites.create_site(%{
-        "slug" => "uses#{System.unique_integer([:positive])}",
-        "name" => "Live Site",
-        "owner_id" => user.id,
-        "theme_id" => theme.id
-      })
+  test "refuses to delete a theme used by a live site and names it", %{user: user, theme: theme} do
+    site = site_using(user, theme, "Live Site")
 
-    assert {:error, {:in_use, sites}} = Themes.delete_theme(theme)
-    assert {site.name, nil} in sites
-    # The theme is untouched.
+    assert {:error, {:in_use, names}} = Themes.delete_theme(theme)
+    assert site.name in names
     assert Themes.get_theme(theme.id)
   end
 
-  test "a soft-deleted site still blocks deletion and is flagged", %{user: user, theme: theme} do
-    {:ok, site} =
-      Sites.create_site(%{
-        "slug" => "uses#{System.unique_integer([:positive])}",
-        "name" => "Gone Site",
-        "owner_id" => user.id,
-        "theme_id" => theme.id
-      })
+  test "a disabled site still blocks deletion", %{user: user, theme: theme} do
+    site = site_using(user, theme, "Disabled Site")
+    {:ok, _} = Sites.disable_site(site)
 
+    assert {:error, {:in_use, names}} = Themes.delete_theme(theme)
+    assert site.name in names
+  end
+
+  test "a soft-deleted site no longer blocks: it is detached onto default", %{
+    user: user,
+    theme: theme
+  } do
+    site = site_using(user, theme, "Gone Site")
     {:ok, _} = Sites.soft_delete_site(site)
 
-    assert {:error, {:in_use, [{name, deleted_at}]}} = Themes.delete_theme(theme)
-    assert name == site.name
-    refute is_nil(deleted_at)
+    assert {:ok, _} = Themes.delete_theme(theme)
+    refute Themes.get_theme(theme.id)
+
+    default = Themes.get_built_in_by_slug("default")
+    assert Repo.get(Masthead.Sites.Site, site.id).theme_id == default.id
   end
 end


### PR DESCRIPTION
A soft-deleted site still holds its sites.theme_id foreign key, so it would pin an uploaded theme forever even though it renders nothing. delete_theme/1 now detaches soft-deleted sites onto the built-in default theme before deleting, while live and disabled sites still block (a disabled site can be re-enabled). The in-use error now returns plain site names instead of {name, deleted_at} tuples.