### PR TITLE
feat: extract theme settings into a dedicated Theme page

### DIFF
--- a/lib/masthead_web/live/admin/components.ex
+++ b/lib/masthead_web/live/admin/components.ex
@@ -14,7 +14,8 @@ defmodule MastheadWeb.AdminLive.Components do
 
   attr :active, :atom,
     default: nil,
-    doc: ":overview | :posts | :pages | :uploads | :settings | :checklist | :sites | :themes"
+    doc:
+      ":overview | :posts | :pages | :uploads | :theme | :settings | :checklist | :sites | :themes"
 
   attr :action_count, :integer,
     default: nil,
@@ -91,6 +92,9 @@ defmodule MastheadWeb.AdminLive.Components do
             </.nav_link>
             <.nav_link href={~p"/#{@site.slug}/uploads"} label="Uploads" active={@active == :uploads}>
               <.icon_image />
+            </.nav_link>
+            <.nav_link href={~p"/#{@site.slug}/theme"} label="Theme" active={@active == :theme}>
+              <.icon_palette />
             </.nav_link>
             <.nav_link
               href={~p"/#{@site.slug}/settings"}

--- a/lib/masthead_web/live/admin/site_settings.ex
+++ b/lib/masthead_web/live/admin/site_settings.ex
@@ -3,53 +3,37 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
   on_mount {MastheadWeb.AdminLive.Hooks, :load_site}
 
   import MastheadWeb.AdminLive.Components
-  alias Masthead.{Actions, Sites, Themes, Content, Uploads}
+  alias Masthead.{Actions, Sites, Content}
 
   @impl true
   def mount(_params, _session, socket) do
     site = socket.assigns.site
     changeset = Sites.change_settings(site)
-    themes = Themes.list_themes(socket.assigns.current_user.id)
 
     {:ok,
      socket
      |> assign(
        page_title: "Settings — #{site.name}",
-       themes: themes,
        published_pages: Content.list_published_pages(site.id),
-       site_uploads: Uploads.list_uploads(site.id),
        action_count: Actions.count_pending(site),
-       show_errors: false,
-       open_token_group: nil,
-       selected_theme: pick_theme(themes, current_theme_id(changeset, site))
+       show_errors: false
      )
      |> assign_form(changeset)}
   end
 
   @impl true
-  # Track the single open token-category accordion server-side, so a form
-  # re-render (phx-change while typing) doesn't reset the native `<details>`
-  # state. Only one category is open at a time; clicking the open one closes it.
-  def handle_event("toggle_token_group", %{"group" => group}, socket) do
-    open = if socket.assigns.open_token_group == group, do: nil, else: group
-    {:noreply, assign(socket, open_token_group: open)}
-  end
-
   def handle_event("validate", %{"site" => params}, socket) do
     changeset =
       socket.assigns.site
       |> Sites.change_settings(params)
       |> Map.put(:action, :validate)
 
-    selected = pick_theme(socket.assigns.themes, current_theme_id(changeset, socket.assigns.site))
-
-    {:noreply, socket |> assign(selected_theme: selected) |> assign_form(changeset)}
+    {:noreply, assign_form(socket, changeset)}
   end
 
   def handle_event("save", %{"site" => params}, socket) do
     case Sites.update_settings(socket.assigns.site, params) do
       {:ok, site} ->
-        Masthead.Themes.Loader.invalidate(site.theme_id)
         changeset = Sites.change_settings(site)
 
         {:noreply,
@@ -57,8 +41,7 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
          |> assign(
            site: site,
            published_pages: Content.list_published_pages(site.id),
-           action_count: Actions.count_pending(site),
-           selected_theme: pick_theme(socket.assigns.themes, site.theme_id)
+           action_count: Actions.count_pending(site)
          )
          |> put_flash(:info, "Settings saved.")
          |> assign_form(changeset)}
@@ -80,187 +63,11 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
      |> push_navigate(to: ~p"/sites")}
   end
 
-  # ---- file-token picker ----
-  # The picker UI lives in the shared `FilePicker` LiveComponent; it reports
-  # the chosen upload back here via `{:file_picked, upload, context}`.
-
-  def handle_event("clear_token", %{"token" => key}, socket) do
-    {:noreply, assign_form(socket, set_token(socket, key, ""))}
-  end
-
-  @impl true
-  def handle_info({:file_picked, upload, %{"token" => key}}, socket) do
-    value = if upload, do: to_string(upload.id), else: ""
-    changeset = set_token(socket, key, value)
-
-    # A freshly uploaded file must be in the list so the field can show it.
-    socket =
-      if upload,
-        do: assign(socket, site_uploads: Uploads.list_uploads(socket.assigns.site.id)),
-        else: socket
-
-    {:noreply, assign_form(socket, changeset)}
-  end
-
   defp assign_form(socket, changeset) do
     assign(socket, form: to_form(changeset, as: :site), changeset: changeset)
   end
 
-  defp current_theme_id(changeset, site) do
-    case Ecto.Changeset.get_field(changeset, :theme_id) do
-      nil -> site.theme_id
-      id -> id
-    end
-  end
-
-  defp pick_theme(themes, nil), do: List.first(themes)
-
-  defp pick_theme(themes, id) do
-    Enum.find(themes, List.first(themes), fn t -> t.id == id end)
-  end
-
   defp homepage_value(form), do: form[:homepage_page_id].value
-
-  # Manifest tokens are stored on the row as a plain map. Pull out the
-  # token definitions (key/label/type/default) so the template can render
-  # an input per token.
-  defp token_definitions(nil), do: []
-
-  defp token_definitions(%Masthead.Themes.Theme{manifest: %{} = m}) do
-    case Map.get(m, "tokens", Map.get(m, :tokens, [])) do
-      list when is_list(list) ->
-        Enum.map(list, fn t ->
-          %{
-            key: t["key"] || t[:key],
-            label: t["label"] || t[:label],
-            type: t["type"] || t[:type],
-            default: t["default"] || t[:default],
-            options: t["options"] || t[:options] || [],
-            category: t["category"] || t[:category]
-          }
-        end)
-
-      _ ->
-        []
-    end
-  end
-
-  # Decide how to lay out the token fields:
-  #   * `{:flat, tokens}`    — no token declares a category; render as a
-  #     single list (unchanged behaviour).
-  #   * `{:grouped, groups}` — at least one token has a category; render one
-  #     accordion per category, in first-appearance order, with uncategorized
-  #     tokens collected under "General".
-  defp token_groups(theme) do
-    tokens = token_definitions(theme)
-
-    if Enum.any?(tokens, &categorized?/1) do
-      {:grouped, group_tokens(tokens)}
-    else
-      {:flat, tokens}
-    end
-  end
-
-  defp categorized?(%{category: c}) when is_binary(c), do: String.trim(c) != ""
-  defp categorized?(_), do: false
-
-  defp token_category(tok),
-    do: if(categorized?(tok), do: String.trim(tok.category), else: "General")
-
-  defp group_tokens(tokens) do
-    Enum.reduce(tokens, [], fn tok, acc ->
-      cat = token_category(tok)
-
-      case List.keyfind(acc, cat, 0) do
-        nil -> acc ++ [{cat, [tok]}]
-        {^cat, list} -> List.keyreplace(acc, cat, 0, {cat, list ++ [tok]})
-      end
-    end)
-  end
-
-  defp token_value(form, key) do
-    case form[:theme_tokens].value do
-      %{} = m -> Map.get(m, key) || Map.get(m, to_string(key)) || ""
-      _ -> ""
-    end
-  end
-
-  # The value shown in a token input: the per-site override if set, else the
-  # manifest default — so the field (and especially the color picker, which
-  # has no placeholder) reflects the effective value rather than a blank.
-  defp token_display_value(form, tok) do
-    case token_value(form, tok.key) do
-      "" -> to_string(tok.default || "")
-      value -> value
-    end
-  end
-
-  # Value for a token <input>. Color has no placeholder, so it's pre-filled
-  # with the effective value (override-or-default) to avoid showing black.
-  # Every other input is left at the override only, so the manifest default
-  # surfaces as the placeholder instead.
-  defp token_input_value(form, %{type: "color"} = tok), do: token_display_value(form, tok)
-  defp token_input_value(form, tok), do: token_value(form, tok.key)
-
-  # Always give text inputs a placeholder: the manifest default, or the
-  # token's label when there's no default.
-  defp token_placeholder(tok) do
-    case to_string(tok.default || "") do
-      "" -> to_string(tok.label || "")
-      default -> default
-    end
-  end
-
-  defp html_input_type("color"), do: "color"
-  defp html_input_type("number"), do: "number"
-  defp html_input_type(_), do: "text"
-
-  # Resolve a file token's stored upload id to the upload struct (for the
-  # selected-file preview), or nil when unset / dangling.
-  defp selected_upload(_uploads, value) when value in [nil, ""], do: nil
-
-  defp selected_upload(uploads, value) do
-    Enum.find(uploads, fn u -> to_string(u.id) == to_string(value) end)
-  end
-
-  defp file_ext(filename) do
-    filename |> Path.extname() |> String.trim_leading(".") |> String.upcase()
-  end
-
-  # Capitalize only the first letter for display (keeps the rest as-authored,
-  # unlike String.capitalize/1 which lowercases the tail).
-  defp capitalize_first(opt) do
-    case to_string(opt) do
-      <<first::utf8, rest::binary>> -> String.upcase(<<first::utf8>>) <> rest
-      other -> other
-    end
-  end
-
-  # Rebuild the settings changeset with one theme token set/cleared, while
-  # preserving the user's other in-progress (unsaved) field edits. A blank
-  # value drops the key (mirrors normalize_theme_tokens).
-  defp set_token(socket, key, value) do
-    changeset = socket.assigns.changeset
-    tokens = Ecto.Changeset.get_field(changeset, :theme_tokens) || %{}
-
-    tokens =
-      if value in [nil, ""],
-        do: Map.delete(tokens, to_string(key)),
-        else: Map.put(tokens, to_string(key), to_string(value))
-
-    params = Map.put(editable_params(changeset), "theme_tokens", tokens)
-
-    socket.assigns.site
-    |> Sites.change_settings(params)
-    |> Map.put(:action, :validate)
-  end
-
-  defp editable_params(changeset) do
-    for field <- [:name, :title, :description, :theme_id, :theme_css_overrides, :homepage_page_id],
-        into: %{} do
-      {to_string(field), Ecto.Changeset.get_field(changeset, field)}
-    end
-  end
 
   defp domain_status_label("pending_dns"), do: "awaiting DNS"
   defp domain_status_label("verified"), do: "verified"
@@ -318,7 +125,7 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
           <div class="settings-section">
             <header class="settings-section-head">
               <h2>Public site</h2>
-              <p>Control what visitors see at the root URL and how the site is styled.</p>
+              <p>Control what visitors see at the root URL.</p>
             </header>
 
             <div class="settings-fields">
@@ -337,94 +144,6 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
                   </option>
                 </select>
                 <small>Pick a page to override the default post list.</small>
-              </label>
-
-              <fieldset class="theme-picker">
-                <legend>Theme</legend>
-                <label
-                  :for={t <- @themes}
-                  class={"theme-picker-card" <> if(@selected_theme && t.id == @selected_theme.id, do: " theme-picker-card-selected", else: "")}
-                >
-                  <input
-                    type="radio"
-                    name="site[theme_id]"
-                    value={t.id}
-                    checked={@selected_theme && t.id == @selected_theme.id}
-                  />
-                  <span class="theme-picker-card-name">{t.name}</span>
-                </label>
-                <.link class="theme-picker-card theme-picker-card-add" navigate={~p"/themes"}>
-                  <span class="theme-picker-card-icon" aria-hidden="true">+</span>
-                </.link>
-                <small class="theme-picker-hint">
-                  Rendering style applied to the public site.
-                </small>
-              </fieldset>
-            </div>
-          </div>
-
-          <div
-            :if={@selected_theme && token_definitions(@selected_theme) != []}
-            class="settings-section"
-          >
-            <header class="settings-section-head">
-              <h2>Theme customization</h2>
-              <p>Override the {@selected_theme.name} theme's design tokens.</p>
-            </header>
-
-            <%= case token_groups(@selected_theme) do %>
-              <% {:flat, tokens} -> %>
-                <div class="settings-fields">
-                  <.token_field
-                    :for={tok <- tokens}
-                    tok={tok}
-                    form={@form}
-                    site={@site}
-                    site_uploads={@site_uploads}
-                  />
-                </div>
-              <% {:grouped, groups} -> %>
-                <div class="token-groups">
-                  <details
-                    :for={{category, tokens} <- groups}
-                    class="token-group"
-                    open={@open_token_group == category}
-                  >
-                    <summary
-                      class="token-group-summary"
-                      phx-click="toggle_token_group"
-                      phx-value-group={category}
-                    >
-                      {category}
-                    </summary>
-                    <div class="settings-fields">
-                      <.token_field
-                        :for={tok <- tokens}
-                        tok={tok}
-                        form={@form}
-                        site={@site}
-                        site_uploads={@site_uploads}
-                      />
-                    </div>
-                  </details>
-                </div>
-            <% end %>
-          </div>
-
-          <div :if={@selected_theme} class="settings-section">
-            <header class="settings-section-head">
-              <h2>Custom CSS</h2>
-              <p>Optional escape hatch — appended after the theme's stylesheet.</p>
-            </header>
-
-            <div class="settings-fields">
-              <label>
-                CSS overrides <textarea
-                  name="site[theme_css_overrides]"
-                  rows="6"
-                  placeholder=".my-class { color: red; }"
-                >{@form[:theme_css_overrides].value}</textarea>
-                <small>Up to 50 KB. No imports or external resources.</small>
               </label>
             </div>
           </div>
@@ -487,90 +206,7 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
           </div>
         </.form>
       </div>
-
-      <.live_component
-        module={MastheadWeb.AdminLive.FilePicker}
-        id="settings-file-picker"
-        site={@site}
-        accept={~w(.png .jpg .jpeg .gif .webp .svg .ico .pdf)}
-        clearable
-      />
     </.shell>
-    """
-  end
-
-  attr :tok, :map, required: true
-  attr :form, :any, required: true
-  attr :site, :map, required: true
-  attr :site_uploads, :list, required: true
-
-  defp token_field(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :selected,
-        selected_upload(assigns.site_uploads, token_value(assigns.form, assigns.tok.key))
-      )
-
-    ~H"""
-    <label>
-      {@tok.label}
-      <div :if={@tok.type == "file"} class="token-file">
-        <input
-          type="hidden"
-          name={"site[theme_tokens][" <> @tok.key <> "]"}
-          value={token_value(@form, @tok.key)}
-        />
-        <span :if={@selected} class="token-file-thumb">
-          <img :if={Uploads.image?(@selected)} src={Uploads.url(@selected)} alt="" />
-          <span :if={not Uploads.image?(@selected)} class="file-badge file-badge-sm">
-            {file_ext(@selected.filename)}
-          </span>
-        </span>
-        <span :if={@selected} class="token-file-name">{@selected.filename}</span>
-        <span :if={is_nil(@selected)} class="token-file-empty">No file selected</span>
-        <div class="token-file-actions">
-          <button
-            type="button"
-            class="btn btn-sm"
-            phx-click="open"
-            phx-target="#settings-file-picker"
-            phx-value-token={@tok.key}
-            phx-value-current={token_value(@form, @tok.key)}
-          >
-            {if @selected, do: "Change", else: "Choose file"}
-          </button>
-          <button
-            :if={@selected}
-            type="button"
-            class="btn btn-sm"
-            phx-click="clear_token"
-            phx-value-token={@tok.key}
-          >
-            Remove
-          </button>
-        </div>
-      </div>
-      <select :if={@tok.type == "select"} name={"site[theme_tokens][" <> @tok.key <> "]"}>
-        <option
-          :for={opt <- @tok.options}
-          value={opt}
-          selected={to_string(opt) == to_string(token_display_value(@form, @tok))}
-        >
-          {capitalize_first(opt)}
-        </option>
-      </select>
-      <input
-        :if={@tok.type != "file" and @tok.type != "select"}
-        type={html_input_type(@tok.type)}
-        name={"site[theme_tokens][" <> @tok.key <> "]"}
-        value={token_input_value(@form, @tok)}
-        placeholder={token_placeholder(@tok)}
-      />
-      <small :if={@tok.type == "color" and @tok.default != ""}>
-        Default: <code>{@tok.default}</code>
-      </small>
-    </label>
     """
   end
 end

--- a/lib/masthead_web/live/admin/site_theme.ex
+++ b/lib/masthead_web/live/admin/site_theme.ex
@@ -1,0 +1,458 @@
+defmodule MastheadWeb.AdminLive.SiteTheme do
+  use MastheadWeb, :live_view
+  on_mount {MastheadWeb.AdminLive.Hooks, :load_site}
+
+  import MastheadWeb.AdminLive.Components
+  alias Masthead.{Actions, Sites, Themes, Uploads}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    site = socket.assigns.site
+    changeset = Sites.change_settings(site)
+    themes = Themes.list_themes(socket.assigns.current_user.id)
+
+    {:ok,
+     socket
+     |> assign(
+       page_title: "Theme — #{site.name}",
+       themes: themes,
+       site_uploads: Uploads.list_uploads(site.id),
+       action_count: Actions.count_pending(site),
+       show_errors: false,
+       open_token_group: nil,
+       selected_theme: pick_theme(themes, current_theme_id(changeset, site))
+     )
+     |> assign_form(changeset)}
+  end
+
+  @impl true
+  # Track the single open token-category accordion server-side, so a form
+  # re-render (phx-change while typing) doesn't reset the native `<details>`
+  # state. Only one category is open at a time; clicking the open one closes it.
+  def handle_event("toggle_token_group", %{"group" => group}, socket) do
+    open = if socket.assigns.open_token_group == group, do: nil, else: group
+    {:noreply, assign(socket, open_token_group: open)}
+  end
+
+  def handle_event("validate", %{"site" => params}, socket) do
+    changeset =
+      socket.assigns.site
+      |> Sites.change_settings(params)
+      |> Map.put(:action, :validate)
+
+    selected = pick_theme(socket.assigns.themes, current_theme_id(changeset, socket.assigns.site))
+
+    {:noreply, socket |> assign(selected_theme: selected) |> assign_form(changeset)}
+  end
+
+  def handle_event("save", %{"site" => params}, socket) do
+    case Sites.update_settings(socket.assigns.site, params) do
+      {:ok, site} ->
+        Masthead.Themes.Loader.invalidate(site.theme_id)
+        changeset = Sites.change_settings(site)
+
+        {:noreply,
+         socket
+         |> assign(
+           site: site,
+           action_count: Actions.count_pending(site),
+           selected_theme: pick_theme(socket.assigns.themes, site.theme_id)
+         )
+         |> put_flash(:info, "Theme saved.")
+         |> assign_form(changeset)}
+
+      {:error, changeset} ->
+        {:noreply, socket |> assign(show_errors: true) |> assign_form(changeset)}
+    end
+  end
+
+  # ---- file-token picker ----
+  # The picker UI lives in the shared `FilePicker` LiveComponent; it reports
+  # the chosen upload back here via `{:file_picked, upload, context}`.
+
+  def handle_event("clear_token", %{"token" => key}, socket) do
+    {:noreply, assign_form(socket, set_token(socket, key, ""))}
+  end
+
+  @impl true
+  def handle_info({:file_picked, upload, %{"token" => key}}, socket) do
+    value = if upload, do: to_string(upload.id), else: ""
+    changeset = set_token(socket, key, value)
+
+    # A freshly uploaded file must be in the list so the field can show it.
+    socket =
+      if upload,
+        do: assign(socket, site_uploads: Uploads.list_uploads(socket.assigns.site.id)),
+        else: socket
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  defp assign_form(socket, changeset) do
+    assign(socket, form: to_form(changeset, as: :site), changeset: changeset)
+  end
+
+  defp current_theme_id(changeset, site) do
+    case Ecto.Changeset.get_field(changeset, :theme_id) do
+      nil -> site.theme_id
+      id -> id
+    end
+  end
+
+  defp pick_theme(themes, nil), do: List.first(themes)
+
+  defp pick_theme(themes, id) do
+    Enum.find(themes, List.first(themes), fn t -> t.id == id end)
+  end
+
+  # Manifest tokens are stored on the row as a plain map. Pull out the
+  # token definitions (key/label/type/default) so the template can render
+  # an input per token.
+  defp token_definitions(nil), do: []
+
+  defp token_definitions(%Masthead.Themes.Theme{manifest: %{} = m}) do
+    case Map.get(m, "tokens", Map.get(m, :tokens, [])) do
+      list when is_list(list) ->
+        Enum.map(list, fn t ->
+          %{
+            key: t["key"] || t[:key],
+            label: t["label"] || t[:label],
+            type: t["type"] || t[:type],
+            default: t["default"] || t[:default],
+            options: t["options"] || t[:options] || [],
+            category: t["category"] || t[:category]
+          }
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  # Decide how to lay out the token fields:
+  #   * `{:flat, tokens}`    — no token declares a category; render as a
+  #     single list (unchanged behaviour).
+  #   * `{:grouped, groups}` — at least one token has a category; render one
+  #     accordion per category, in first-appearance order, with uncategorized
+  #     tokens collected under "General".
+  defp token_groups(theme) do
+    tokens = token_definitions(theme)
+
+    if Enum.any?(tokens, &categorized?/1) do
+      {:grouped, group_tokens(tokens)}
+    else
+      {:flat, tokens}
+    end
+  end
+
+  defp categorized?(%{category: c}) when is_binary(c), do: String.trim(c) != ""
+  defp categorized?(_), do: false
+
+  defp token_category(tok),
+    do: if(categorized?(tok), do: String.trim(tok.category), else: "General")
+
+  defp group_tokens(tokens) do
+    Enum.reduce(tokens, [], fn tok, acc ->
+      cat = token_category(tok)
+
+      case List.keyfind(acc, cat, 0) do
+        nil -> acc ++ [{cat, [tok]}]
+        {^cat, list} -> List.keyreplace(acc, cat, 0, {cat, list ++ [tok]})
+      end
+    end)
+  end
+
+  defp token_value(form, key) do
+    case form[:theme_tokens].value do
+      %{} = m -> Map.get(m, key) || Map.get(m, to_string(key)) || ""
+      _ -> ""
+    end
+  end
+
+  # The value shown in a token input: the per-site override if set, else the
+  # manifest default — so the field (and especially the color picker, which
+  # has no placeholder) reflects the effective value rather than a blank.
+  defp token_display_value(form, tok) do
+    case token_value(form, tok.key) do
+      "" -> to_string(tok.default || "")
+      value -> value
+    end
+  end
+
+  # Value for a token <input>. Color has no placeholder, so it's pre-filled
+  # with the effective value (override-or-default) to avoid showing black.
+  # Every other input is left at the override only, so the manifest default
+  # surfaces as the placeholder instead.
+  defp token_input_value(form, %{type: "color"} = tok), do: token_display_value(form, tok)
+  defp token_input_value(form, tok), do: token_value(form, tok.key)
+
+  # Always give text inputs a placeholder: the manifest default, or the
+  # token's label when there's no default.
+  defp token_placeholder(tok) do
+    case to_string(tok.default || "") do
+      "" -> to_string(tok.label || "")
+      default -> default
+    end
+  end
+
+  defp html_input_type("color"), do: "color"
+  defp html_input_type("number"), do: "number"
+  defp html_input_type(_), do: "text"
+
+  # Resolve a file token's stored upload id to the upload struct (for the
+  # selected-file preview), or nil when unset / dangling.
+  defp selected_upload(_uploads, value) when value in [nil, ""], do: nil
+
+  defp selected_upload(uploads, value) do
+    Enum.find(uploads, fn u -> to_string(u.id) == to_string(value) end)
+  end
+
+  defp file_ext(filename) do
+    filename |> Path.extname() |> String.trim_leading(".") |> String.upcase()
+  end
+
+  # Capitalize only the first letter for display (keeps the rest as-authored,
+  # unlike String.capitalize/1 which lowercases the tail).
+  defp capitalize_first(opt) do
+    case to_string(opt) do
+      <<first::utf8, rest::binary>> -> String.upcase(<<first::utf8>>) <> rest
+      other -> other
+    end
+  end
+
+  # Rebuild the changeset with one theme token set/cleared, while preserving
+  # the user's other in-progress (unsaved) theme edits. A blank value drops
+  # the key (mirrors normalize_theme_tokens).
+  defp set_token(socket, key, value) do
+    changeset = socket.assigns.changeset
+    tokens = Ecto.Changeset.get_field(changeset, :theme_tokens) || %{}
+
+    tokens =
+      if value in [nil, ""],
+        do: Map.delete(tokens, to_string(key)),
+        else: Map.put(tokens, to_string(key), to_string(value))
+
+    params = Map.put(editable_params(changeset), "theme_tokens", tokens)
+
+    socket.assigns.site
+    |> Sites.change_settings(params)
+    |> Map.put(:action, :validate)
+  end
+
+  defp editable_params(changeset) do
+    for field <- [:theme_id, :theme_css_overrides],
+        into: %{} do
+      {to_string(field), Ecto.Changeset.get_field(changeset, field)}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.shell
+      title="Theme"
+      site={@site}
+      current_user={@current_user}
+      flash={@flash}
+      active={:theme}
+      action_count={@action_count}
+    >
+      <div class="wizard">
+        <.form
+          for={@form}
+          phx-change="validate"
+          phx-submit="save"
+          class="form settings-form"
+          id="site-theme-form"
+        >
+          <.error_list changeset={@changeset} show={@show_errors} />
+
+          <div class="settings-section">
+            <header class="settings-section-head">
+              <h2>Theme</h2>
+              <p>The rendering style applied to your public site.</p>
+            </header>
+
+            <div class="settings-fields">
+              <fieldset class="theme-picker">
+                <legend class="sr-only">Theme</legend>
+                <label
+                  :for={t <- @themes}
+                  class={"theme-picker-card" <> if(@selected_theme && t.id == @selected_theme.id, do: " theme-picker-card-selected", else: "")}
+                >
+                  <input
+                    type="radio"
+                    name="site[theme_id]"
+                    value={t.id}
+                    checked={@selected_theme && t.id == @selected_theme.id}
+                  />
+                  <span class="theme-picker-card-name">{t.name}</span>
+                </label>
+                <.link class="theme-picker-card theme-picker-card-add" navigate={~p"/themes"}>
+                  <span class="theme-picker-card-icon" aria-hidden="true">+</span>
+                </.link>
+              </fieldset>
+            </div>
+          </div>
+
+          <div
+            :if={@selected_theme && token_definitions(@selected_theme) != []}
+            class="settings-section"
+          >
+            <header class="settings-section-head">
+              <h2>Theme customization</h2>
+              <p>Override the {@selected_theme.name} theme's design tokens.</p>
+            </header>
+
+            <%= case token_groups(@selected_theme) do %>
+              <% {:flat, tokens} -> %>
+                <div class="settings-fields">
+                  <.token_field
+                    :for={tok <- tokens}
+                    tok={tok}
+                    form={@form}
+                    site={@site}
+                    site_uploads={@site_uploads}
+                  />
+                </div>
+              <% {:grouped, groups} -> %>
+                <div class="token-groups">
+                  <details
+                    :for={{category, tokens} <- groups}
+                    class="token-group"
+                    open={@open_token_group == category}
+                  >
+                    <summary
+                      class="token-group-summary"
+                      phx-click="toggle_token_group"
+                      phx-value-group={category}
+                    >
+                      {category}
+                    </summary>
+                    <div class="settings-fields">
+                      <.token_field
+                        :for={tok <- tokens}
+                        tok={tok}
+                        form={@form}
+                        site={@site}
+                        site_uploads={@site_uploads}
+                      />
+                    </div>
+                  </details>
+                </div>
+            <% end %>
+          </div>
+
+          <div :if={@selected_theme} class="settings-section">
+            <header class="settings-section-head">
+              <h2>Custom CSS</h2>
+              <p>Optional escape hatch — appended after the theme's stylesheet.</p>
+            </header>
+
+            <div class="settings-fields">
+              <label>
+                CSS overrides <textarea
+                  name="site[theme_css_overrides]"
+                  rows="6"
+                  placeholder=".my-class { color: red; }"
+                >{@form[:theme_css_overrides].value}</textarea>
+                <small>Up to 50 KB. No imports or external resources.</small>
+              </label>
+            </div>
+          </div>
+
+          <div class="wizard-footer">
+            <.link navigate={~p"/#{@site.slug}"} class="btn">Cancel</.link>
+            <button type="submit" class="btn btn-primary" data-shortcut="save">
+              Save theme
+            </button>
+          </div>
+        </.form>
+      </div>
+
+      <.live_component
+        module={MastheadWeb.AdminLive.FilePicker}
+        id="theme-file-picker"
+        site={@site}
+        accept={~w(.png .jpg .jpeg .gif .webp .svg .ico .pdf)}
+        clearable
+      />
+    </.shell>
+    """
+  end
+
+  attr :tok, :map, required: true
+  attr :form, :any, required: true
+  attr :site, :map, required: true
+  attr :site_uploads, :list, required: true
+
+  defp token_field(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :selected,
+        selected_upload(assigns.site_uploads, token_value(assigns.form, assigns.tok.key))
+      )
+
+    ~H"""
+    <label>
+      {@tok.label}
+      <div :if={@tok.type == "file"} class="token-file">
+        <input
+          type="hidden"
+          name={"site[theme_tokens][" <> @tok.key <> "]"}
+          value={token_value(@form, @tok.key)}
+        />
+        <span :if={@selected} class="token-file-thumb">
+          <img :if={Uploads.image?(@selected)} src={Uploads.url(@selected)} alt="" />
+          <span :if={not Uploads.image?(@selected)} class="file-badge file-badge-sm">
+            {file_ext(@selected.filename)}
+          </span>
+        </span>
+        <span :if={@selected} class="token-file-name">{@selected.filename}</span>
+        <span :if={is_nil(@selected)} class="token-file-empty">No file selected</span>
+        <div class="token-file-actions">
+          <button
+            type="button"
+            class="btn btn-sm"
+            phx-click="open"
+            phx-target="#theme-file-picker"
+            phx-value-token={@tok.key}
+            phx-value-current={token_value(@form, @tok.key)}
+          >
+            {if @selected, do: "Change", else: "Choose file"}
+          </button>
+          <button
+            :if={@selected}
+            type="button"
+            class="btn btn-sm"
+            phx-click="clear_token"
+            phx-value-token={@tok.key}
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+      <select :if={@tok.type == "select"} name={"site[theme_tokens][" <> @tok.key <> "]"}>
+        <option
+          :for={opt <- @tok.options}
+          value={opt}
+          selected={to_string(opt) == to_string(token_display_value(@form, @tok))}
+        >
+          {capitalize_first(opt)}
+        </option>
+      </select>
+      <input
+        :if={@tok.type != "file" and @tok.type != "select"}
+        type={html_input_type(@tok.type)}
+        name={"site[theme_tokens][" <> @tok.key <> "]"}
+        value={token_input_value(@form, @tok)}
+        placeholder={token_placeholder(@tok)}
+      />
+      <small :if={@tok.type == "color" and @tok.default != ""}>
+        Default: <code>{@tok.default}</code>
+      </small>
+    </label>
+    """
+  end
+end

--- a/lib/masthead_web/router.ex
+++ b/lib/masthead_web/router.ex
@@ -78,6 +78,7 @@ defmodule MastheadWeb.Router do
 
       live "/:site_slug", AdminLive.SiteDashboard, :show
       live "/:site_slug/settings", AdminLive.SiteSettings, :edit
+      live "/:site_slug/theme", AdminLive.SiteTheme, :edit
       live "/:site_slug/checklist", AdminLive.Checklist, :index
       live "/:site_slug/domain", AdminLive.DomainSetup, :show
 

--- a/test/masthead_web/site_settings_live_test.exs
+++ b/test/masthead_web/site_settings_live_test.exs
@@ -3,7 +3,7 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
 
   import Phoenix.LiveViewTest
 
-  alias Masthead.{Accounts, Sites, Themes, Uploads}
+  alias Masthead.{Accounts, Sites, Themes}
 
   setup do
     Masthead.Themes.Seed.run()
@@ -32,152 +32,26 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
     %{conn: conn, site: site}
   end
 
-  test "a theme without token categories renders the tokens flat", %{conn: conn, site: site} do
-    # The default theme's only token (accent) has no category → no accordion.
-    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/settings")
-    refute html =~ "token-group"
-  end
-
-  test "a theme with token categories renders accordions, uncategorized under General", %{
-    conn: conn,
-    site: site
-  } do
-    tailwind = Themes.get_built_in_by_slug("tailwind")
-    {:ok, site} = Sites.update_settings(site, %{"theme_id" => tailwind.id})
-
+  test "the settings page no longer carries the theme controls", %{conn: conn, site: site} do
     {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/settings")
 
-    assert html =~ "token-group-summary"
-    assert html =~ ~s(phx-value-group="Header")
-    assert html =~ ~s(phx-value-group="Footer")
-    # logo/favicon/accent/cta have no category → grouped under General.
-    assert html =~ ~s(phx-value-group="General")
+    # Theme selection/customization now lives on its own /theme page.
+    refute html =~ "theme-picker"
+    refute html =~ ~s(name="site[theme_id]")
+    assert html =~ "Identity"
+    assert html =~ "Custom domain"
   end
 
-  test "an opened category stays open across a form change, and only one opens at a time", %{
-    conn: conn,
-    site: site
-  } do
-    tailwind = Themes.get_built_in_by_slug("tailwind")
-    {:ok, site} = Sites.update_settings(site, %{"theme_id" => tailwind.id})
-    {:ok, lv, _} = live(conn, ~p"/#{site.slug}/settings")
-
-    open_header = ~r/<details[^>]*\bopen\b[^>]*>\s*<summary[^>]*phx-value-group="Header"/
-
-    # Open the Header group.
-    html = lv |> element(~s(summary[phx-value-group="Header"])) |> render_click()
-    assert html =~ open_header
-
-    # A form change (what previously closed it) keeps it open.
-    html = lv |> form("#site-settings-form", site: %{name: "Renamed"}) |> render_change()
-    assert html =~ open_header
-
-    # Opening Footer closes Header (single-open accordion).
-    html = lv |> element(~s(summary[phx-value-group="Footer"])) |> render_click()
-    refute html =~ open_header
-    assert html =~ ~r/<details[^>]*\bopen\b[^>]*>\s*<summary[^>]*phx-value-group="Footer"/
-  end
-
-  test "a file token renders a picker that lists the site's uploads in a modal", %{
-    conn: conn,
-    site: site
-  } do
-    upload = create_upload(site, "brand.png")
-
-    {:ok, lv, html} = live(conn, ~p"/#{site.slug}/settings")
-
-    # The field carries a hidden value input and a "Choose file" trigger —
-    # no inline <select>. The picker (and its options) is closed initially.
-    assert html =~ ~s(name="site[theme_tokens][favicon]")
-    assert html =~ "Choose file"
-    refute html =~ "Upload new"
-
-    # Opening the picker reveals the upload as a card, a "No file" option, and
-    # an "Upload new" add-card.
-    html =
-      lv
-      |> element(~s(button[phx-click="open"][phx-value-token="favicon"]))
-      |> render_click()
-
-    assert html =~ "No file"
-    assert html =~ "brand.png"
-    assert html =~ ~s(phx-value-id="#{upload.id}")
-    assert html =~ "Upload new"
-  end
-
-  test "selecting an upload and saving persists its id as the token value", %{
-    conn: conn,
-    site: site
-  } do
-    upload = create_upload(site, "icon.png")
-
+  test "identity fields can be edited and saved", %{conn: conn, site: site} do
     {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/settings")
 
     lv
-    |> element(~s(button[phx-click="open"][phx-value-token="favicon"]))
-    |> render_click()
-
-    # Clicking a card selects it (the picker reports back to the LiveView,
-    # which sets the token); the field now shows the chosen filename.
-    lv
-    |> element(~s(button[phx-click="select"][phx-value-id="#{upload.id}"]))
-    |> render_click()
-
-    assert render(lv) =~ "icon.png"
-
-    # Selection is part of the settings form; Save persists it.
-    lv |> form("#site-settings-form") |> render_submit()
+    |> form("#site-settings-form", site: %{name: "Renamed", description: "A fresh tagline."})
+    |> render_submit()
 
     site = Sites.get_site!(site.id)
-    assert site.theme_tokens["favicon"] == to_string(upload.id)
-  end
-
-  test "uploading a new file in the picker stores it and selects it", %{conn: conn, site: site} do
-    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/settings")
-
-    lv
-    |> element(~s(button[phx-click="open"][phx-value-token="favicon"]))
-    |> render_click()
-
-    # The uploader lives behind the "Upload new" add-card.
-    lv |> element(~s(button[phx-click="show_upload"])) |> render_click()
-
-    file =
-      file_input(lv, "#settings-file-picker-upload-form", :file, [
-        %{name: "fresh.png", content: "imgbytes", type: "image/png"}
-      ])
-
-    render_upload(file, "fresh.png")
-    lv |> element("#settings-file-picker-upload-form") |> render_submit()
-
-    # Stored and immediately selected for the active token.
-    assert render(lv) =~ "fresh.png"
-    fresh = Enum.find(Uploads.list_uploads(site.id), &(&1.filename == "fresh.png"))
-    assert fresh
-
-    lv |> form("#site-settings-form") |> render_submit()
-    site = Sites.get_site!(site.id)
-    assert site.theme_tokens["favicon"] == to_string(fresh.id)
-  end
-
-  test "token inputs are pre-filled with the manifest default when unset", %{
-    conn: conn,
-    site: site
-  } do
-    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/settings")
-
-    # The default theme's accent token defaults to #0066cc — the (color)
-    # input must carry that as its value, not render blank/black.
-    assert html =~ ~s(value="#0066cc")
-  end
-
-  test "a saved override is shown instead of the default", %{conn: conn, site: site} do
-    {:ok, site} = Sites.update_settings(site, %{"theme_tokens" => %{"accent" => "#ff0000"}})
-
-    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/settings")
-
-    assert html =~ ~s(value="#ff0000")
-    refute html =~ ~s(value="#0066cc")
+    assert site.name == "Renamed"
+    assert site.description == "A fresh tagline."
   end
 
   test "the owner can soft-delete their site from the danger zone", %{conn: conn, site: site} do
@@ -191,16 +65,5 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
     # no longer resolvable as their site.
     assert Sites.get_site!(site.id).deleted_at != nil
     assert Sites.list_sites_for_user(site.owner_id) == []
-  end
-
-  defp create_upload(site, filename) do
-    tmp = Path.join(System.tmp_dir!(), "ss-up-#{System.unique_integer([:positive])}.png")
-    File.write!(tmp, "bytes")
-
-    {:ok, upload} =
-      Uploads.store_image(site, %{filename: filename, content_type: "image/png", path: tmp})
-
-    File.rm(tmp)
-    upload
   end
 end

--- a/test/masthead_web/site_theme_live_test.exs
+++ b/test/masthead_web/site_theme_live_test.exs
@@ -1,0 +1,206 @@
+defmodule MastheadWeb.SiteThemeLiveTest do
+  use MastheadWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Masthead.{Accounts, Sites, Themes, Uploads}
+
+  setup do
+    Masthead.Themes.Seed.run()
+
+    {:ok, user} =
+      Accounts.register_user(%{
+        "email" => "st-#{System.unique_integer([:positive])}@example.com",
+        "password" => "password1234"
+      })
+
+    default = Themes.get_built_in_by_slug("default")
+
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "st#{System.unique_integer([:positive])}",
+        "name" => "ST Test",
+        "owner_id" => user.id,
+        "theme_id" => default.id
+      })
+
+    conn =
+      build_conn()
+      |> Plug.Test.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_id, user.id)
+
+    %{conn: conn, site: site}
+  end
+
+  test "the selected theme can be changed and saved", %{conn: conn, site: site} do
+    tailwind = Themes.get_built_in_by_slug("tailwind")
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/theme")
+
+    lv
+    |> form("#site-theme-form", site: %{theme_id: tailwind.id})
+    |> render_submit()
+
+    assert Sites.get_site!(site.id).theme_id == tailwind.id
+  end
+
+  test "a theme without token categories renders the tokens flat", %{conn: conn, site: site} do
+    # The default theme's only token (accent) has no category → no accordion.
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/theme")
+    refute html =~ "token-group"
+  end
+
+  test "a theme with token categories renders accordions, uncategorized under General", %{
+    conn: conn,
+    site: site
+  } do
+    tailwind = Themes.get_built_in_by_slug("tailwind")
+    {:ok, site} = Sites.update_settings(site, %{"theme_id" => tailwind.id})
+
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/theme")
+
+    assert html =~ "token-group-summary"
+    assert html =~ ~s(phx-value-group="Header")
+    assert html =~ ~s(phx-value-group="Footer")
+    # logo/favicon/accent/cta have no category → grouped under General.
+    assert html =~ ~s(phx-value-group="General")
+  end
+
+  test "an opened category stays open across a form change, and only one opens at a time", %{
+    conn: conn,
+    site: site
+  } do
+    tailwind = Themes.get_built_in_by_slug("tailwind")
+    {:ok, site} = Sites.update_settings(site, %{"theme_id" => tailwind.id})
+    {:ok, lv, _} = live(conn, ~p"/#{site.slug}/theme")
+
+    open_header = ~r/<details[^>]*\bopen\b[^>]*>\s*<summary[^>]*phx-value-group="Header"/
+
+    # Open the Header group.
+    html = lv |> element(~s(summary[phx-value-group="Header"])) |> render_click()
+    assert html =~ open_header
+
+    # A form change (what previously closed it) keeps it open.
+    html =
+      lv |> form("#site-theme-form", site: %{theme_css_overrides: "/* x */"}) |> render_change()
+
+    assert html =~ open_header
+
+    # Opening Footer closes Header (single-open accordion).
+    html = lv |> element(~s(summary[phx-value-group="Footer"])) |> render_click()
+    refute html =~ open_header
+    assert html =~ ~r/<details[^>]*\bopen\b[^>]*>\s*<summary[^>]*phx-value-group="Footer"/
+  end
+
+  test "a file token renders a picker that lists the site's uploads in a modal", %{
+    conn: conn,
+    site: site
+  } do
+    upload = create_upload(site, "brand.png")
+
+    {:ok, lv, html} = live(conn, ~p"/#{site.slug}/theme")
+
+    # The field carries a hidden value input and a "Choose file" trigger —
+    # no inline <select>. The picker (and its options) is closed initially.
+    assert html =~ ~s(name="site[theme_tokens][favicon]")
+    assert html =~ "Choose file"
+    refute html =~ "Upload new"
+
+    # Opening the picker reveals the upload as a card, a "No file" option, and
+    # an "Upload new" add-card.
+    html =
+      lv
+      |> element(~s(button[phx-click="open"][phx-value-token="favicon"]))
+      |> render_click()
+
+    assert html =~ "No file"
+    assert html =~ "brand.png"
+    assert html =~ ~s(phx-value-id="#{upload.id}")
+    assert html =~ "Upload new"
+  end
+
+  test "selecting an upload and saving persists its id as the token value", %{
+    conn: conn,
+    site: site
+  } do
+    upload = create_upload(site, "icon.png")
+
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/theme")
+
+    lv
+    |> element(~s(button[phx-click="open"][phx-value-token="favicon"]))
+    |> render_click()
+
+    # Clicking a card selects it (the picker reports back to the LiveView,
+    # which sets the token); the field now shows the chosen filename.
+    lv
+    |> element(~s(button[phx-click="select"][phx-value-id="#{upload.id}"]))
+    |> render_click()
+
+    assert render(lv) =~ "icon.png"
+
+    # Selection is part of the theme form; Save persists it.
+    lv |> form("#site-theme-form") |> render_submit()
+
+    site = Sites.get_site!(site.id)
+    assert site.theme_tokens["favicon"] == to_string(upload.id)
+  end
+
+  test "uploading a new file in the picker stores it and selects it", %{conn: conn, site: site} do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/theme")
+
+    lv
+    |> element(~s(button[phx-click="open"][phx-value-token="favicon"]))
+    |> render_click()
+
+    # The uploader lives behind the "Upload new" add-card.
+    lv |> element(~s(button[phx-click="show_upload"])) |> render_click()
+
+    file =
+      file_input(lv, "#theme-file-picker-upload-form", :file, [
+        %{name: "fresh.png", content: "imgbytes", type: "image/png"}
+      ])
+
+    render_upload(file, "fresh.png")
+    lv |> element("#theme-file-picker-upload-form") |> render_submit()
+
+    # Stored and immediately selected for the active token.
+    assert render(lv) =~ "fresh.png"
+    fresh = Enum.find(Uploads.list_uploads(site.id), &(&1.filename == "fresh.png"))
+    assert fresh
+
+    lv |> form("#site-theme-form") |> render_submit()
+    site = Sites.get_site!(site.id)
+    assert site.theme_tokens["favicon"] == to_string(fresh.id)
+  end
+
+  test "token inputs are pre-filled with the manifest default when unset", %{
+    conn: conn,
+    site: site
+  } do
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/theme")
+
+    # The default theme's accent token defaults to #0066cc — the (color)
+    # input must carry that as its value, not render blank/black.
+    assert html =~ ~s(value="#0066cc")
+  end
+
+  test "a saved override is shown instead of the default", %{conn: conn, site: site} do
+    {:ok, site} = Sites.update_settings(site, %{"theme_tokens" => %{"accent" => "#ff0000"}})
+
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/theme")
+
+    assert html =~ ~s(value="#ff0000")
+    refute html =~ ~s(value="#0066cc")
+  end
+
+  defp create_upload(site, filename) do
+    tmp = Path.join(System.tmp_dir!(), "st-up-#{System.unique_integer([:positive])}.png")
+    File.write!(tmp, "bytes")
+
+    {:ok, upload} =
+      Uploads.store_image(site, %{filename: filename, content_type: "image/png", path: tmp})
+
+    File.rm(tmp)
+    upload
+  end
+end


### PR DESCRIPTION
Move the theme picker, design-token customization, and custom CSS out of site Settings into a new /:site_slug/theme page (AdminLive.SiteTheme) with its own sidebar entry, lightening Settings to identity, homepage, custom domain, and the danger zone.

Both pages edit the same site row via Sites.update_settings; cast ignores absent fields and validate_required falls back to existing values, so each form safely saves only its own subset. The theme page keeps Loader.invalidate on save.

Tests: move the theme/token suite to site_theme_live_test.exs, trim the settings test, and assert Settings no longer renders theme controls.