### PR TITLE
feat: point custom-domain CNAME target at masthead.site

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,11 +25,13 @@ config :masthead, :site_url,
   port: 4000
 
 # Custom-domain feature. `cname_target` is the hostname users point
-# their domain's CNAME at (the Fly app's edge); `txt_prefix` is the
+# their domain's CNAME at — our own branded edge host, not the
+# underlying `*.fly.dev` app name, so the target is stable and never
+# exposes the hosting provider to customers' DNS. `txt_prefix` is the
 # label under which the ownership token is published as a TXT record.
-# Prod overrides `cname_target` from FLY_APP_NAME in runtime.exs.
+# Prod overrides `cname_target` from the primary app host in runtime.exs.
 config :masthead, :custom_domain,
-  cname_target: "dijkstra-masthead.fly.dev",
+  cname_target: "masthead.site",
   txt_prefix: "_masthead-verify"
 
 # Configure the endpoint

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -89,13 +89,13 @@ if config_env() == :prod do
     host: List.first(app_hosts),
     port: nil
 
-  # Custom domains: users CNAME their domain at the Fly app's edge.
-  # Derive the target from FLY_APP_NAME so it tracks the deployed app.
-  if fly_app = System.get_env("FLY_APP_NAME") do
-    config :masthead, :custom_domain,
-      cname_target: "#{fly_app}.fly.dev",
-      txt_prefix: "_masthead-verify"
-  end
+  # Custom domains: users delegate by CNAME-ing their domain at our
+  # primary app host (a stable, branded edge we control) rather than the
+  # underlying `*.fly.dev` app name — so the target survives infra
+  # changes and never leaks the hosting provider into customers' DNS.
+  config :masthead, :custom_domain,
+    cname_target: List.first(app_hosts),
+    txt_prefix: "_masthead-verify"
 
   config :masthead, MastheadWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],

--- a/lib/masthead/custom_domains.ex
+++ b/lib/masthead/custom_domains.ex
@@ -266,7 +266,7 @@ defmodule Masthead.CustomDomains do
 
   defp cname_target do
     Application.get_env(:masthead, :custom_domain, [])
-    |> Keyword.get(:cname_target, "dijkstra-masthead.fly.dev")
+    |> Keyword.get(:cname_target, "masthead.site")
   end
 
   defp txt_prefix do

--- a/lib/masthead/custom_domains/dns_resolver.ex
+++ b/lib/masthead/custom_domains/dns_resolver.ex
@@ -75,7 +75,7 @@ defmodule Masthead.CustomDomains.DnsResolver.Stub do
 
       config :masthead, :dns_stub, %{
         txt: %{"_masthead-verify.blog.example.com" => ["token123"]},
-        cname: %{"blog.example.com" => ["dijkstra-masthead.fly.dev"]}
+        cname: %{"blog.example.com" => ["masthead.site"]}
       }
   """
   @behaviour Masthead.CustomDomains.DnsResolver

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.7.0",
+      version: "2.7.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/masthead/custom_domains_test.exs
+++ b/test/masthead/custom_domains_test.exs
@@ -3,7 +3,9 @@ defmodule Masthead.CustomDomainsTest do
 
   alias Masthead.{Accounts, Sites, CustomDomains}
 
-  @cname_target "dijkstra-masthead.fly.dev"
+  # Read the configured target so this stays in sync with config rather
+  # than hardcoding a value that can silently drift from the real one.
+  @cname_target Application.compile_env(:masthead, [:custom_domain, :cname_target])
 
   setup do
     Masthead.Themes.Seed.run()


### PR DESCRIPTION
Use our own branded edge host as the custom-domain CNAME target instead of the underlying *.fly.dev app name. Traffic is unchanged — Fly routes by the per-domain cert/Host header, and a customer CNAME to masthead.site resolves to the same Fly anycast IPs — but the target is now stable across infra changes and never leaks the hosting provider into customers' DNS. The single config value drives both the setup instructions and the delegation verification check, so they stay in sync.

Prod derives the target from the primary app host (app_hosts) rather than FLY_APP_NAME. Bumps version to 2.7.1.