### PR TITLE
feat: optimize homepage for SEO and GEO

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2641,6 +2641,84 @@ button.danger:hover { filter: brightness(0.92); }
   margin: 0;
 }
 
+/* FAQ */
+.landing-faq {
+  max-width: 1100px;
+  margin: 0 auto 5rem;
+  padding: 0 1.5rem;
+}
+.landing-faq .section-title {
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  letter-spacing: -0.02em;
+  margin: 0 0 2rem;
+  font-weight: 600;
+}
+.faq-list {
+  display: grid;
+  gap: 0.75rem;
+}
+.faq-item {
+  background: var(--landing-card);
+  border: 1px solid var(--landing-rule);
+  border-radius: 12px;
+  padding: 0 1.5rem;
+  transition: border-color 0.18s ease;
+}
+.faq-item[open] {
+  border-color: var(--landing-accent);
+}
+.faq-item summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 0;
+  cursor: pointer;
+  list-style: none;
+}
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+.faq-item summary h3 {
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+  margin: 0;
+  font-weight: 600;
+  color: var(--landing-fg);
+}
+.faq-marker {
+  position: relative;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
+}
+.faq-marker::before,
+.faq-marker::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 2px;
+  background: var(--landing-accent);
+  border-radius: 2px;
+  transform: translate(-50%, -50%);
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+.faq-marker::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+.faq-item[open] .faq-marker::after {
+  opacity: 0;
+}
+.faq-item p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--landing-fg-soft);
+  margin: 0;
+  padding: 0 0 1.4rem;
+}
+
 /* Bottom CTA */
 .landing-cta {
   max-width: 1100px;

--- a/lib/masthead_web.ex
+++ b/lib/masthead_web.ex
@@ -17,7 +17,7 @@ defmodule MastheadWeb do
   those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt sitemap.xml)
 
   def router do
     quote do

--- a/lib/masthead_web/components/layouts/root.html.heex
+++ b/lib/masthead_web/components/layouts/root.html.heex
@@ -5,6 +5,41 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <.live_title default="Home" suffix=" · Masthead" phx-no-format>{assigns[:page_title]}</.live_title>
+    <meta
+      name="description"
+      content={
+        assigns[:meta_description] ||
+          "Masthead is an open-source, multi-tenant publishing platform for blogs and small business sites. Custom domains, Markdown or HTML, themes, and automatic HTTPS."
+      }
+    />
+    <meta :if={assigns[:noindex]} name="robots" content="noindex, nofollow" />
+    <link :if={assigns[:canonical_url]} rel="canonical" href={@canonical_url} />
+    <meta name="theme-color" content="#2563eb" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Masthead" />
+    <meta property="og:title" content={assigns[:og_title] || assigns[:page_title] || "Masthead"} />
+    <meta
+      property="og:description"
+      content={
+        assigns[:meta_description] ||
+          "Open-source, multi-tenant publishing platform for blogs and small business sites."
+      }
+    />
+    <meta :if={assigns[:canonical_url]} property="og:url" content={@canonical_url} />
+    <meta property="og:image" content={assigns[:og_image] || url(~p"/images/logo.png")} />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={assigns[:og_title] || assigns[:page_title] || "Masthead"} />
+    <meta
+      name="twitter:description"
+      content={
+        assigns[:meta_description] ||
+          "Open-source, multi-tenant publishing platform for blogs and small business sites."
+      }
+    />
+    <meta name="twitter:image" content={assigns[:og_image] || url(~p"/images/logo.png")} />
+    <script :if={assigns[:json_ld]} type="application/ld+json" phx-no-format><%= raw(Jason.encode!(@json_ld)) %></script>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
     </script>

--- a/lib/masthead_web/controllers/page_controller.ex
+++ b/lib/masthead_web/controllers/page_controller.ex
@@ -1,10 +1,85 @@
 defmodule MastheadWeb.PageController do
   use MastheadWeb, :controller
 
+  @meta_description "Masthead is an open-source, multi-tenant publishing platform for blogs and small business sites. Custom domains, Markdown or HTML, themes, and automatic HTTPS."
+
+  @github_url "https://github.com/JoeriDijkstra/masthead"
+
+  # Visible FAQ on the homepage and the FAQPage structured data are generated
+  # from this single source so they always stay in sync (a requirement for
+  # Google's FAQ rich results and a strong signal for AI answer engines).
+  @faqs [
+    {"What is Masthead?",
+     "Masthead is an open-source, multi-tenant publishing platform for blogs and small business websites. Each site runs on its own subdomain or custom domain, with content written in Markdown or HTML."},
+    {"Is Masthead free and open source?",
+     "Yes. Masthead is open source and the full source is available on GitHub, so you can self-host it or audit exactly how it works."},
+    {"Can I use my own domain?",
+     "Yes. You can point any custom domain — apex or subdomain — at a Masthead site. TLS certificates are provisioned automatically and your site is served over HTTPS as soon as DNS resolves."},
+    {"Do I need to know how to code?",
+     "No. You can write posts and pages in Markdown without any coding. If you want full control over design, you can also write raw HTML and upload custom themes."},
+    {"Can I run more than one site?",
+     "Yes. You can run unlimited sites from a single account, each with its own content, theme, and domain, all managed from one dashboard."}
+  ]
+
   def home(conn, _params) do
     case conn.assigns[:current_user] do
-      nil -> render(conn, :home)
-      _user -> redirect(conn, to: "/sites")
+      nil ->
+        conn
+        |> assign(:page_title, "Open-source publishing for blogs & small business sites")
+        |> assign(:og_title, "Masthead — open-source publishing for blogs & small business sites")
+        |> assign(:meta_description, @meta_description)
+        |> assign(:canonical_url, url(~p"/"))
+        |> assign(:og_image, url(~p"/images/logo.png"))
+        |> assign(:faqs, @faqs)
+        |> assign(:json_ld, home_json_ld())
+        |> render(:home)
+
+      _user ->
+        redirect(conn, to: "/sites")
     end
+  end
+
+  defp home_json_ld do
+    home = url(~p"/")
+    logo = url(~p"/images/logo.png")
+
+    [
+      %{
+        "@context" => "https://schema.org",
+        "@type" => "Organization",
+        "name" => "Masthead",
+        "url" => home,
+        "logo" => logo,
+        "sameAs" => [@github_url]
+      },
+      %{
+        "@context" => "https://schema.org",
+        "@type" => "WebSite",
+        "name" => "Masthead",
+        "url" => home
+      },
+      %{
+        "@context" => "https://schema.org",
+        "@type" => "SoftwareApplication",
+        "name" => "Masthead",
+        "applicationCategory" => "Content management system",
+        "operatingSystem" => "Web",
+        "url" => home,
+        "description" => @meta_description,
+        "offers" => %{"@type" => "Offer", "price" => "0", "priceCurrency" => "USD"}
+      },
+      %{
+        "@context" => "https://schema.org",
+        "@type" => "FAQPage",
+        "mainEntity" =>
+          Enum.map(@faqs, fn {question, answer} ->
+            %{
+              "@type" => "Question",
+              "name" => question,
+              "acceptedAnswer" => %{"@type" => "Answer", "text" => answer}
+            }
+          end)
+      }
+    ]
   end
 end

--- a/lib/masthead_web/controllers/page_html/home.html.heex
+++ b/lib/masthead_web/controllers/page_html/home.html.heex
@@ -223,6 +223,20 @@
     </ul>
   </section>
 
+  <section class="landing-faq" aria-labelledby="faq-title">
+    <h2 class="section-title" id="faq-title">Frequently asked questions</h2>
+
+    <div class="faq-list">
+      <details :for={{question, answer} <- @faqs} class="faq-item">
+        <summary>
+          <h3>{question}</h3>
+          <span class="faq-marker" aria-hidden="true"></span>
+        </summary>
+        <p>{answer}</p>
+      </details>
+    </div>
+  </section>
+
   <section class="landing-cta">
     <div class="cta-card">
       <h2>Get started today.</h2>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.7.1",
+      version: "2.8.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -1,5 +1,14 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /sites
+Disallow: /account
+Disallow: /login
+Disallow: /signup
+Disallow: /reset-password
+Disallow: /confirm
+Disallow: /auth
+
+Sitemap: https://masthead.site/sitemap.xml

--- a/priv/static/sitemap.xml
+++ b/priv/static/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://masthead.site/</loc>
+    <lastmod>2026-06-12</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/test/masthead_web/controllers/page_controller_test.exs
+++ b/test/masthead_web/controllers/page_controller_test.exs
@@ -7,4 +7,25 @@ defmodule MastheadWeb.PageControllerTest do
     assert html_response(conn, 200) =~
              "Simple websites without the complexity of traditional CMS platforms."
   end
+
+  test "GET / renders SEO metadata", %{conn: conn} do
+    html = conn |> get(~p"/") |> html_response(200)
+
+    assert html =~ ~s(<meta name="description")
+    assert html =~ "open-source, multi-tenant publishing platform"
+    assert html =~ ~s(rel="canonical")
+    assert html =~ ~s(property="og:title")
+    assert html =~ ~s(name="twitter:card")
+  end
+
+  test "GET / embeds JSON-LD structured data for answer engines", %{conn: conn} do
+    html = conn |> get(~p"/") |> html_response(200)
+
+    assert html =~ ~s(<script type="application/ld+json")
+    assert html =~ "SoftwareApplication"
+    assert html =~ "FAQPage"
+    # Visible FAQ content must be present so it matches the FAQPage schema.
+    assert html =~ "What is Masthead?"
+    assert html =~ "Can I use my own domain?"
+  end
 end


### PR DESCRIPTION
Add assign-driven meta tags (description, canonical, Open Graph, Twitter Card) to the root layout with site-wide defaults, and set rich values on the marketing homepage. Emit JSON-LD structured data (Organization, WebSite, SoftwareApplication, FAQPage) for search and generative answer engines, with a visible FAQ section generated from the same source so it stays in sync with the schema. Add robots.txt crawl directives + sitemap reference and a static sitemap.xml.

Bumps version to 2.8.0.