### PR TITLE
feat: admin console improvements (timestamps, URL state, tooltips)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -992,15 +992,60 @@ button.danger:hover { filter: brightness(0.92); }
 .row-title { color: var(--accent); font-weight: 500; }
 .row-link:hover .row-title { text-decoration: underline; }
 
-/* Relative timestamp ("a day ago"); the exact date is in its title tooltip,
-   hinted by the dotted underline + help cursor. */
+/* Relative timestamp ("a day ago"); the exact date is in a custom tooltip
+   (from `data-tooltip`), hinted by the dotted underline + help cursor. */
 .rel-time {
+  position: relative;
   color: var(--muted);
   cursor: help;
   white-space: nowrap;
   text-decoration: underline dotted;
   text-decoration-color: var(--rule-strong);
   text-underline-offset: 2px;
+}
+
+/* Black tooltip bubble + arrow above the label. Custom (not the native
+   `title`) so it appears near-instantly instead of after the ~1s UA delay.
+   Positioned above so it stays inside the table's overflow box (it overlays
+   the row above / the header rather than escaping the table). */
+.rel-time::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 7px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #000;
+  color: #fff;
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.4rem 0.55rem;
+  border-radius: 6px;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.rel-time::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #000;
+  border-bottom: none;
+  z-index: 10;
+}
+
+.rel-time::before,
+.rel-time::after {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 80ms ease-out 100ms;
+}
+
+.rel-time:hover::before,
+.rel-time:hover::after {
+  opacity: 1;
 }
 
 /* On phones, a multi-column table is unreadable. Tables opting in with

--- a/lib/masthead/accounts.ex
+++ b/lib/masthead/accounts.ex
@@ -358,6 +358,12 @@ defmodule Masthead.Accounts do
     end
   end
 
+  @doc "Stamps the user's last successful login. Called from `UserAuth.log_in_user/3`."
+  def record_login(%User{} = user) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    user |> Ecto.Changeset.change(last_login_at: now) |> Repo.update()
+  end
+
   @doc "Marks a user's email confirmed without a token (admin verify)."
   def verify_user(%User{} = user), do: user |> User.confirm_changeset() |> Repo.update()
 

--- a/lib/masthead/accounts/user.ex
+++ b/lib/masthead/accounts/user.ex
@@ -8,6 +8,7 @@ defmodule Masthead.Accounts.User do
     field :hashed_password, :string, redact: true
     field :confirmed_at, :utc_datetime
     field :disabled_at, :utc_datetime
+    field :last_login_at, :utc_datetime
     field :wants_onboarding_emails, :boolean, default: true
     field :admin, :boolean, default: false
 

--- a/lib/masthead_web/live/admin/components.ex
+++ b/lib/masthead_web/live/admin/components.ex
@@ -292,7 +292,8 @@ defmodule MastheadWeb.AdminLive.Components do
 
   @doc """
   Renders a timestamp as a relative label (e.g. "a day ago") with the exact
-  date shown in a native hover tooltip. Renders nothing when `at` is nil.
+  date and time shown in a custom hover tooltip (see `.rel-time` in app.css).
+  Renders nothing when `at` is nil.
   """
   def relative_time(assigns) do
     ~H"""
@@ -300,7 +301,7 @@ defmodule MastheadWeb.AdminLive.Components do
       :if={@at}
       class="rel-time"
       datetime={DateTime.to_iso8601(@at)}
-      title={Calendar.strftime(@at, "%b %-d, %Y at %-I:%M %p UTC")}
+      data-tooltip={Calendar.strftime(@at, "%b %-d, %Y at %-I:%M %p UTC")}
     >
       {relative_label(@at)}
     </time>

--- a/lib/masthead_web/live/admin/console.ex
+++ b/lib/masthead_web/live/admin/console.ex
@@ -6,6 +6,8 @@ defmodule MastheadWeb.AdminLive.Console do
 
   alias Masthead.{Accounts, Actions, Sites, Themes}
 
+  @default_filters %{users: :all, sites: :enabled, themes: :all}
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -15,18 +17,52 @@ defmodule MastheadWeb.AdminLive.Console do
        tab: :users,
        action_modal?: false,
        action_site: nil,
-       users_filter: :all,
+       users_filter: @default_filters.users,
        users_search: "",
-       sites_filter: :all,
+       sites_filter: @default_filters.sites,
        sites_search: "",
-       themes_filter: :all,
+       themes_filter: @default_filters.themes,
        themes_search: ""
-     )
-     |> load_data()}
+     )}
   end
 
+  # Tab and filter live in the URL (`/admin/:tab/:filter` or `?filter=`),
+  # so views are shareable. Unknown values fall back to the defaults.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    tab = parse_tab(params)
+    socket = assign(socket, tab: tab)
+
+    socket =
+      case parse_filter(tab, params) do
+        nil -> socket
+        filter -> assign(socket, :"#{tab}_filter", filter)
+      end
+
+    {:noreply, load_data(socket)}
+  end
+
+  defp parse_tab(%{"tab" => tab}) when tab in ~w(users sites themes),
+    do: String.to_existing_atom(tab)
+
+  defp parse_tab(_params), do: :users
+
+  defp parse_filter(tab, %{"filter" => filter}) do
+    Enum.find_value(filter_options(tab), fn {value, _label} ->
+      if Atom.to_string(value) == filter, do: value
+    end)
+  end
+
+  defp parse_filter(_tab, _params), do: nil
+
+  # Always include the filter segment: a bare `/admin/:tab` keeps whatever
+  # filter is currently assigned, so e.g. "All" must link to `/users/all`
+  # explicitly to reset it.
+  defp admin_path(tab, filter), do: ~p"/admin/#{tab}/#{filter}"
+
   # Filter buttons offered per tab. The atoms match the context
-  # `apply_filter/2` clauses, so `String.to_existing_atom/1` is safe.
+  # `apply_filter/2` clauses; this list also whitelists the `:filter`
+  # URL param in `parse_filter/2`.
   defp filter_options(:users),
     do: [
       {:all, "All"},
@@ -37,7 +73,7 @@ defmodule MastheadWeb.AdminLive.Console do
     ]
 
   defp filter_options(:sites),
-    do: [{:all, "All"}, {:enabled, "Enabled"}, {:disabled, "Disabled"}, {:deleted, "Deleted"}]
+    do: [{:enabled, "Enabled"}, {:disabled, "Disabled"}, {:deleted, "Deleted"}]
 
   defp filter_options(:themes),
     do: [
@@ -62,8 +98,9 @@ defmodule MastheadWeb.AdminLive.Console do
   end
 
   @impl true
-  def handle_event("switch_tab", %{"tab" => tab}, socket) do
-    {:noreply, assign(socket, tab: String.to_existing_atom(tab))}
+  def handle_event("switch_tab", %{"tab" => tab}, socket) when tab in ~w(users sites themes) do
+    tab = String.to_existing_atom(tab)
+    {:noreply, push_patch(socket, to: admin_path(tab, socket.assigns[:"#{tab}_filter"]))}
   end
 
   # ---- users ----
@@ -116,8 +153,9 @@ defmodule MastheadWeb.AdminLive.Console do
   # ---- filtering & search (users / sites / themes) ----
 
   def handle_event("switch_filter", %{"scope" => scope, "filter" => filter}, socket) do
-    key = String.to_existing_atom("#{scope}_filter")
-    {:noreply, socket |> assign(key, String.to_existing_atom(filter)) |> load_data()}
+    tab = parse_tab(%{"tab" => scope})
+    filter = parse_filter(tab, %{"filter" => filter}) || @default_filters[tab]
+    {:noreply, push_patch(socket, to: admin_path(tab, filter))}
   end
 
   def handle_event("search_list", %{"scope" => scope, "query" => query}, socket) do
@@ -175,6 +213,7 @@ defmodule MastheadWeb.AdminLive.Console do
               <th>Status</th>
               <th>Role</th>
               <th>Joined</th>
+              <th>Last login</th>
               <th></th>
             </tr>
           </thead>
@@ -188,7 +227,11 @@ defmodule MastheadWeb.AdminLive.Console do
                 <span :if={Accounts.User.disabled?(u)} class="pill pill-danger">disabled</span>
               </td>
               <td>{if u.admin, do: "admin", else: "—"}</td>
-              <td class="muted">{Calendar.strftime(u.inserted_at, "%b %-d, %Y")}</td>
+              <td class="muted"><.relative_time at={u.inserted_at} /></td>
+              <td class="muted">
+                <.relative_time :if={u.last_login_at} at={u.last_login_at} />
+                <span :if={is_nil(u.last_login_at)}>—</span>
+              </td>
               <td class="admin-row-actions">
                 <button
                   :if={not Accounts.User.confirmed?(u)}
@@ -237,6 +280,7 @@ defmodule MastheadWeb.AdminLive.Console do
               <th>Name</th>
               <th>Slug</th>
               <th>Owner</th>
+              <th>Created</th>
               <th>Status</th>
               <th>Add action</th>
               <th></th>
@@ -247,6 +291,7 @@ defmodule MastheadWeb.AdminLive.Console do
               <td>{s.name}</td>
               <td class="muted">{s.slug}</td>
               <td class="muted">{s.owner && s.owner.email}</td>
+              <td class="muted"><.relative_time at={s.inserted_at} /></td>
               <td>
                 <span :if={not is_nil(s.deleted_at)} class="pill pill-danger">deleted</span>
                 <span

--- a/lib/masthead_web/router.ex
+++ b/lib/masthead_web/router.ex
@@ -68,6 +68,8 @@ defmodule MastheadWeb.Router do
     live_session :admin,
       on_mount: [{MastheadWeb.UserAuth, :require_admin}] do
       live "/admin", AdminLive.Console, :index
+      live "/admin/:tab", AdminLive.Console, :index
+      live "/admin/:tab/:filter", AdminLive.Console, :index
     end
 
     live_session :authenticated,

--- a/lib/masthead_web/user_auth.ex
+++ b/lib/masthead_web/user_auth.ex
@@ -13,6 +13,7 @@ defmodule MastheadWeb.UserAuth do
 
   def log_in_user(conn, user, params \\ %{}) do
     return_to = get_session(conn, :user_return_to)
+    {:ok, _} = Accounts.record_login(user)
 
     conn
     |> renew_session()

--- a/priv/repo/migrations/20260612133816_add_last_login_to_users.exs
+++ b/priv/repo/migrations/20260612133816_add_last_login_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Masthead.Repo.Migrations.AddLastLoginToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :last_login_at, :utc_datetime
+    end
+  end
+end

--- a/test/masthead_web/admin_console_live_test.exs
+++ b/test/masthead_web/admin_console_live_test.exs
@@ -58,6 +58,54 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
     assert html =~ "Tailwind"
   end
 
+  test "tab and filter are read from the URL", %{conn: conn, member: member, site: site} do
+    {:ok, _} = Sites.soft_delete_site(site)
+
+    # Filter as a path segment.
+    {:ok, _lv, html} = live(conn, ~p"/admin/sites/deleted")
+    assert html =~ site.name
+
+    # The default sites view (enabled) hides the deleted site.
+    {:ok, _lv, html} = live(conn, ~p"/admin/sites")
+    refute html =~ site.name
+
+    # Filter as a query param.
+    {:ok, _} = Accounts.verify_user(member)
+    {:ok, _lv, html} = live(conn, ~p"/admin/users?filter=verified")
+    assert html =~ member.email
+  end
+
+  test "switching tab and filter patches the URL", %{conn: conn} do
+    {:ok, lv, _} = live(conn, ~p"/admin")
+
+    lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+    assert_patch(lv, ~p"/admin/sites/enabled")
+
+    lv
+    |> element(~s(button[phx-click="switch_filter"][phx-value-filter="deleted"]))
+    |> render_click()
+
+    assert_patch(lv, ~p"/admin/sites/deleted")
+
+    # "All" on the users tab resets explicitly via /all (a bare /admin/users
+    # would keep the previous filter).
+    lv |> element(~s(button[phx-value-tab="users"])) |> render_click()
+
+    lv
+    |> element(~s(button[phx-click="switch_filter"][phx-value-filter="verified"]))
+    |> render_click()
+
+    assert_patch(lv, ~p"/admin/users/verified")
+
+    lv
+    |> element(
+      ~s(button[phx-click="switch_filter"][phx-value-scope="users"][phx-value-filter="all"])
+    )
+    |> render_click()
+
+    assert_patch(lv, ~p"/admin/users/all")
+  end
+
   test "admin can verify an unverified user", %{conn: conn, member: member} do
     refute Accounts.User.confirmed?(member)
     {:ok, lv, _} = live(conn, ~p"/admin")
@@ -79,6 +127,13 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
 
     assert Sites.get_site!(site.id).disabled_at
 
+    # The list defaults to enabled sites, so switch filters to find it again.
+    lv
+    |> element(
+      ~s(button[phx-click="switch_filter"][phx-value-scope="sites"][phx-value-filter="disabled"])
+    )
+    |> render_click()
+
     lv
     |> element(~s(button[phx-click="enable_site"][phx-value-id="#{site.id}"]))
     |> render_click()
@@ -95,6 +150,13 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
     |> render_click()
 
     assert Sites.get_site!(site.id).deleted_at
+
+    # The list defaults to enabled sites, so switch filters to find it again.
+    lv
+    |> element(
+      ~s(button[phx-click="switch_filter"][phx-value-scope="sites"][phx-value-filter="deleted"])
+    )
+    |> render_click()
 
     lv
     |> element(~s(button[phx-click="restore_site"][phx-value-id="#{site.id}"]))


### PR DESCRIPTION
- Sites tab gets a Created column; users tab gets a Last login column (new users.last_login_at, stamped in UserAuth.log_in_user/3) and the Joined column now uses the shared relative_time component.
- The sites list drops the "All" filter and defaults to enabled.
- Tab and filter live in the URL (/admin/:tab/:filter or ?filter=), so console views are shareable; links always carry the filter segment so e.g. /admin/users/all explicitly resets a previous filter.
- relative_time swaps the native title tooltip for a custom black CSS tooltip that appears near-instantly.