### PR TITLE
feat: add blog/docs links and free up the docs slug

### DIFF
--- a/lib/masthead/sites/site.ex
+++ b/lib/masthead/sites/site.ex
@@ -2,7 +2,7 @@ defmodule Masthead.Sites.Site do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @reserved_slugs ~w(www api app admin dashboard login signup logout auth public assets static help docs sites new themes)
+  @reserved_slugs ~w(www api app admin dashboard login signup logout auth public assets static help sites new themes)
 
   schema "sites" do
     field :slug, :string

--- a/lib/masthead_web/controllers/page_html/home.html.heex
+++ b/lib/masthead_web/controllers/page_html/home.html.heex
@@ -5,6 +5,12 @@
       <span class="brand-name">Masthead</span>
     </a>
     <div class="nav-cta">
+      <a href="https://blog.masthead.site" target="_blank" rel="noopener" class="nav-link">
+        Blog
+      </a>
+      <a href="https://docs.masthead.site" target="_blank" rel="noopener" class="nav-link">
+        Docs
+      </a>
       <a
         href="https://github.com/JoeriDijkstra/masthead"
         target="_blank"
@@ -31,8 +37,7 @@
       <%= if assigns[:current_user] do %>
         <.link navigate={~p"/sites"} class="btn btn-primary btn-sm">Open dashboard &rarr;</.link>
       <% else %>
-        <.link navigate={~p"/login"} class="nav-link">Log in</.link>
-        <.link navigate={~p"/signup"} class="btn btn-primary btn-sm">Sign up</.link>
+        <.link navigate={~p"/login"} class="btn btn-primary btn-sm">Login</.link>
       <% end %>
     </div>
   </nav>
@@ -254,6 +259,8 @@
       <span class="landing-version">v{Application.spec(:masthead, :vsn)}</span>
     </div>
     <div class="landing-footer-links">
+      <a href="https://blog.masthead.site" target="_blank" rel="noopener">Blog</a>
+      <a href="https://docs.masthead.site" target="_blank" rel="noopener">Docs</a>
       <%= if assigns[:current_user] do %>
         <.link navigate={~p"/sites"}>Dashboard</.link>
       <% else %>

--- a/lib/masthead_web/live/admin/components.ex
+++ b/lib/masthead_web/live/admin/components.ex
@@ -117,6 +117,17 @@ defmodule MastheadWeb.AdminLive.Components do
               <span>View site</span>
             </a>
 
+            <a
+              class="nav-item nav-external"
+              href="https://docs.masthead.site"
+              target="_blank"
+              rel="noopener"
+              phx-click={close_nav()}
+            >
+              <.icon_book />
+              <span>Docs</span>
+            </a>
+
             <.nav_link href={~p"/sites"} label="All sites" active={false}>
               <.icon_grid />
             </.nav_link>
@@ -137,6 +148,19 @@ defmodule MastheadWeb.AdminLive.Components do
             >
               <.icon_shield />
             </.nav_link>
+
+            <div class="sidebar-divider"></div>
+
+            <a
+              class="nav-item nav-external"
+              href="https://docs.masthead.site"
+              target="_blank"
+              rel="noopener"
+              phx-click={close_nav()}
+            >
+              <.icon_book />
+              <span>Docs</span>
+            </a>
           <% end %>
         </nav>
 
@@ -812,6 +836,25 @@ defmodule MastheadWeb.AdminLive.Components do
         stroke-linecap="round"
         stroke-linejoin="round"
         d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+      />
+    </svg>
+    """
+  end
+
+  defp icon_book(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="icon"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
       />
     </svg>
     """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.8.1",
+      version: "2.9.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Remove "docs" from reserved site slugs so docs.masthead.site can be hosted as a Masthead site. Add Blog and Docs links to the marketing homepage (nav + footer) and a Docs link to the admin sidebar in both nav states, with a matching book icon.

Bump version to 2.9.0.