### PR TITLE
feat: add joined-at column to site members table

### DIFF
--- a/lib/masthead/accounts/user.ex
+++ b/lib/masthead/accounts/user.ex
@@ -11,6 +11,8 @@ defmodule Masthead.Accounts.User do
     field :last_login_at, :utc_datetime
     field :wants_onboarding_emails, :boolean, default: true
     field :admin, :boolean, default: false
+    # Populated only by `Sites.list_members/1` (the member's site-join time).
+    field :joined_at, :utc_datetime, virtual: true
 
     has_many :tokens, Masthead.Accounts.UserToken
     has_many :memberships, Masthead.Sites.SiteMembership

--- a/lib/masthead/sites.ex
+++ b/lib/masthead/sites.ex
@@ -206,7 +206,8 @@ defmodule Masthead.Sites do
         join: m in SiteMembership,
         on: m.user_id == u.id,
         where: m.site_id == ^site.id,
-        order_by: u.email
+        order_by: u.email,
+        select_merge: %{joined_at: m.inserted_at}
     )
   end
 

--- a/lib/masthead_web/live/admin/site_users.ex
+++ b/lib/masthead_web/live/admin/site_users.ex
@@ -210,6 +210,7 @@ defmodule MastheadWeb.AdminLive.SiteUsers do
           <tr>
             <th>Email</th>
             <th>Status</th>
+            <th>Joined</th>
             <th class="actions-cell"></th>
           </tr>
         </thead>
@@ -224,6 +225,7 @@ defmodule MastheadWeb.AdminLive.SiteUsers do
                 {if User.confirmed?(m), do: "Active", else: "Unconfirmed"}
               </span>
             </td>
+            <td data-label="Joined"><.relative_time at={m.joined_at} /></td>
             <td class="actions-cell">
               <div class="row-actions">
                 <button


### PR DESCRIPTION
Show each member's site-join time on the Users tab via a virtual joined_at merged from the membership row in Sites.list_members/1.


Claude-Session: https://claude.ai/code/session_01UZE4CCHu3RTeRDbK9f6Ve4