### PR TITLE
feat: Cmd/Ctrl+K command palette over posts, pages and uploads

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2577,6 +2577,106 @@ button.danger:hover { filter: brightness(0.92); }
 .picker-card-add:hover .picker-add-icon,
 .picker-card-add:hover .picker-name { color: var(--accent); }
 
+/* Command palette (Cmd/Ctrl+K) */
+
+/* The hidden trigger app.js clicks. Not display:none — it stays in the
+   accessibility tree so the shortcut has a real, labelled control behind it. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+/* Sits high rather than centred: the list grows downward as you type, and a
+   centred palette would jump around while the result count changes. */
+.palette-backdrop { align-items: flex-start; padding-top: 12vh; }
+.palette { max-width: 40rem; }
+.palette-form { margin: 0; }
+.palette-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 1.1rem 1.25rem;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  border-radius: 16px 16px 0 0;
+  font-size: 1.05rem;
+  font-family: inherit;
+  background: transparent;
+  color: var(--fg);
+}
+.palette-input:focus { outline: none; }
+.palette-input::placeholder { color: var(--muted); }
+.palette-empty {
+  padding: 2rem 1.25rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.palette-results {
+  overflow-y: auto;
+  max-height: 22rem;
+  padding: 0.5rem 0;
+}
+.palette-group + .palette-group { border-top: 1px solid var(--rule); }
+.palette-group-title {
+  margin: 0;
+  padding: 0.6rem 1.25rem 0.3rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.palette-group ul { list-style: none; margin: 0; padding: 0; }
+.palette-item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.55rem 1.25rem;
+  color: inherit;
+  text-decoration: none;
+}
+.palette-item:hover { background: var(--bg-soft); text-decoration: none; }
+/* Keyboard cursor. Distinct from :hover so moving the mouse over the list
+   doesn't make it ambiguous which row Enter will open. */
+.palette-item.is-active { background: var(--bg-soft); box-shadow: inset 3px 0 0 var(--accent); }
+.palette-item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.palette-item-meta { flex: none; font-size: 0.78rem; color: var(--muted); }
+.palette-footer {
+  display: flex;
+  gap: 1rem;
+  padding: 0.6rem 1.25rem;
+  border-top: 1px solid var(--rule);
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+.palette-footer kbd {
+  display: inline-block;
+  min-width: 1.1rem;
+  margin-right: 0.2rem;
+  padding: 0.05rem 0.3rem;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--bg);
+  font-family: inherit;
+  font-size: 0.72rem;
+  text-align: center;
+}
+@media (max-width: 640px) {
+  .palette-backdrop { padding-top: 6vh; }
+  .palette-footer { display: none; }
+}
+
 /* Upload show / detail */
 .upload-show {
   display: grid;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -30,6 +30,7 @@ import {BadgePulse} from "./hooks/badge_pulse"
 import {SaveShortcut} from "./hooks/save_shortcut"
 import {SortableList} from "./hooks/sortable_list"
 import {ImageCompress} from "./hooks/image_compress"
+import {CommandPalette} from "./hooks/command_palette"
 
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
@@ -43,6 +44,7 @@ const liveSocket = new LiveSocket("/live", Socket, {
     SaveShortcut,
     SortableList,
     ImageCompress,
+    CommandPalette,
   },
 })
 
@@ -105,6 +107,7 @@ document.querySelectorAll("form[data-confirm-password]").forEach(wirePasswordCon
 //   - Cmd/Ctrl+S        → save
 //   - Cmd/Ctrl+Shift+S  → publish (falls back to save if absent)
 //   - Cmd/Ctrl+F        → focus the list's search box (browser find otherwise)
+//   - Cmd/Ctrl+K        → open the command palette
 //   - c (no modifier)   → new (ignored while typing in an input)
 function isEditableTarget(el) {
   if (!el) return false
@@ -119,6 +122,14 @@ window.addEventListener("keydown", e => {
     const target =
       (e.shiftKey && document.querySelector("[data-shortcut='publish']")) ||
       document.querySelector("[data-shortcut='save']")
+    if (!target) return
+    e.preventDefault()
+    target.click()
+    return
+  }
+
+  if (mod && (e.key === "k" || e.key === "K")) {
+    const target = document.querySelector("[data-shortcut='palette']")
     if (!target) return
     e.preventDefault()
     target.click()

--- a/assets/js/hooks/command_palette.js
+++ b/assets/js/hooks/command_palette.js
@@ -1,0 +1,87 @@
+// Client-side half of the command palette: it remembers what you opened, and
+// keeps the keyboard cursor on screen.
+//
+// ## Recents
+//
+// Recents are per-browser, not per-account, so they live in localStorage
+// rather than the database — there is nothing here worth a table, and a
+// round trip on every palette open would be worse than the feature.
+//
+// The server never trusts what comes back: it re-checks that each path
+// belongs to the current site before rendering it as a link.
+const KEY = "masthead:palette-recents"
+const MAX = 5
+
+function read() {
+  try {
+    const items = JSON.parse(window.localStorage.getItem(KEY) || "[]")
+    return Array.isArray(items) ? items.filter(isEntry).slice(0, MAX) : []
+  } catch (_e) {
+    // Private mode, quota, or someone else's malformed value — recents are
+    // a convenience, so degrade to "none" rather than breaking the palette.
+    return []
+  }
+}
+
+function isEntry(e) {
+  return e && typeof e.label === "string" && typeof e.path === "string"
+}
+
+function write(items) {
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(items.slice(0, MAX)))
+  } catch (_e) {
+    // Nothing to do — the palette works fine without a memory.
+  }
+}
+
+function record(entry) {
+  if (!isEntry(entry)) return
+  // Most recent first, and one row per destination.
+  const rest = read().filter(e => e.path !== entry.path)
+  write([{label: entry.label, meta: entry.meta || "", path: entry.path}, ...rest])
+}
+
+export const CommandPalette = {
+  mounted() {
+    this.send()
+
+    // Mouse clicks navigate through the anchor itself and never reach the
+    // server, so record them here. Keyboard selection goes through the
+    // server, which echoes back a "palette:record" event.
+    // `data-record` is absent on commands and destinations: those are always
+    // on screen anyway, so remembering them would only duplicate a row.
+    this.onClick = e => {
+      const item = e.target.closest(".palette-item")
+      if (!item || item.dataset.record !== "1") return
+      record({
+        label: item.dataset.label,
+        meta: item.dataset.meta,
+        path: item.getAttribute("href")
+      })
+    }
+    this.el.addEventListener("click", this.onClick)
+
+    this.handleEvent("palette:record", entry => {
+      record(entry)
+      this.send()
+    })
+  },
+
+  // The cursor lives on the server, so the row it lands on can be scrolled
+  // out of sight in the results list. Pull it back into view after each
+  // patch. "nearest" scrolls the list only — never the page behind it — and
+  // does nothing when the row is already visible.
+  updated() {
+    const active = this.el.querySelector(".palette-item.is-active")
+    if (active) active.scrollIntoView({block: "nearest"})
+  },
+
+  destroyed() {
+    this.el.removeEventListener("click", this.onClick)
+  },
+
+  send() {
+    this.pushEventTo(this.el, "recents", {items: read()})
+  }
+}

--- a/lib/masthead/content.ex
+++ b/lib/masthead/content.ex
@@ -45,6 +45,7 @@ defmodule Masthead.Content do
       a tag slug (string) to keep only posts carrying that tag. One value,
       not a combination: the toolbar is a single-select row of buttons.
     * `:search` — a string matched (ILIKE) against the post title.
+    * `:limit` — cap the number of rows returned.
   """
   def list_posts(site_id, opts \\ []) do
     from(p in Post,
@@ -54,8 +55,12 @@ defmodule Masthead.Content do
     )
     |> apply_post_filter(Keyword.get(opts, :filter, :all))
     |> apply_post_search(Keyword.get(opts, :search))
+    |> cap(Keyword.get(opts, :limit))
     |> Repo.all()
   end
+
+  defp cap(query, limit) when is_integer(limit), do: limit(query, ^limit)
+  defp cap(query, _limit), do: query
 
   defp apply_post_filter(query, :all), do: query
 
@@ -258,11 +263,13 @@ defmodule Masthead.Content do
     * `:filter` — `:all` (default), `:published` or `:draft`. Pages carry no
       tags, so the status filters are the whole set.
     * `:search` — a string matched (ILIKE) against the page title.
+    * `:limit` — cap the number of rows returned.
   """
   def list_pages(site_id, opts \\ []) do
     from(p in Page, where: p.site_id == ^site_id, order_by: p.title)
     |> apply_page_filter(Keyword.get(opts, :filter, :all))
     |> apply_page_search(Keyword.get(opts, :search))
+    |> cap(Keyword.get(opts, :limit))
     |> Repo.all()
   end
 

--- a/lib/masthead/search.ex
+++ b/lib/masthead/search.ex
@@ -1,0 +1,55 @@
+defmodule Masthead.Search do
+  @moduledoc """
+  Cross-content lookup behind the admin command palette: one term matched
+  against a site's posts, pages and uploads at once.
+
+  Each kind is queried and capped independently rather than merged in SQL —
+  a union would have to rank titles against filenames to decide what falls
+  off the end, and the palette shows the kinds as separate groups anyway.
+  Capping per kind also means a site with a thousand matching uploads still
+  leaves room for its two matching posts.
+
+  Results are the plain schema structs. Turning them into links is the
+  caller's job: contexts don't know about routes.
+  """
+
+  alias Masthead.{Content, Uploads}
+
+  @per_kind 5
+
+  @doc """
+  Searches one site's content. Returns `%{posts: [...], pages: [...],
+  uploads: [...]}`, each capped at `:limit` (default #{@per_kind}).
+
+  A blank term matches nothing rather than everything — an empty palette
+  should stay empty instead of dumping the whole site into it.
+  """
+  def search(site_id, term, opts \\ [])
+
+  def search(site_id, term, opts) when is_binary(term) do
+    case String.trim(term) do
+      "" -> empty()
+      trimmed -> query(site_id, trimmed, Keyword.get(opts, :limit, @per_kind))
+    end
+  end
+
+  def search(_site_id, _term, _opts), do: empty()
+
+  @doc "True when a result set has nothing in it."
+  def empty?(%{posts: [], pages: [], uploads: []}), do: true
+  def empty?(%{}), do: false
+
+  @doc "Total number of results across all kinds."
+  def count(%{posts: posts, pages: pages, uploads: uploads}),
+    do: length(posts) + length(pages) + length(uploads)
+
+  defp query(site_id, term, limit) do
+    %{
+      posts: Content.list_posts(site_id, search: term, limit: limit),
+      pages: Content.list_pages(site_id, search: term, limit: limit),
+      uploads: Uploads.list_uploads(site_id, search: term, limit: limit)
+    }
+  end
+
+  defp empty, do: %{posts: [], pages: [], uploads: []}
+end

--- a/lib/masthead_web/live/admin/command_palette.ex
+++ b/lib/masthead_web/live/admin/command_palette.ex
@@ -1,0 +1,312 @@
+defmodule MastheadWeb.AdminLive.CommandPalette do
+  @moduledoc """
+  Cmd/Ctrl+K search over the current site's posts, pages and uploads, plus a
+  short list of jump-to commands.
+
+  Rendered once by `AdminLive.Components.shell/1`, so every site-scoped
+  admin page gets it without wiring anything up. It is self-contained: it
+  runs its own search and navigates on its own, so the host LiveView needs
+  no `handle_info` clause.
+
+  Opening is deliberately not a JS-only affair. `app.js` clicks the hidden
+  `data-shortcut="palette"` trigger, reusing the same mechanism as the
+  save/publish/new shortcuts rather than inventing a second one.
+
+  An idle palette shows only recently opened items, kept in the browser's
+  localStorage by the `CommandPalette` hook. Typing searches content and
+  filters the commands and sidebar destinations by name.
+
+  Keyboard: Cmd/Ctrl+K toggles it open and shut, type to search, Up/Down to
+  move, Enter to open the highlighted row, Escape to close.
+  """
+  use MastheadWeb, :live_component
+
+  alias Masthead.Search
+
+  @impl true
+  def mount(socket) do
+    {:ok, socket |> assign(recents: []) |> reset()}
+  end
+
+  # Cmd/Ctrl+K toggles: the same keystroke that opened the palette closes it
+  # again, so the shortcut is a switch rather than a one-way door.
+  @impl true
+  def handle_event("toggle", _params, socket) do
+    if socket.assigns.open? do
+      {:noreply, close(socket)}
+    else
+      {:noreply, socket |> reset() |> assign(open?: true)}
+    end
+  end
+
+  def handle_event("close", _params, socket), do: {:noreply, close(socket)}
+
+  def handle_event("search", %{"query" => query}, socket) do
+    results = Search.search(socket.assigns.site.id, query)
+    {:noreply, assign(socket, query: query, results: results, cursor: 0)}
+  end
+
+  # Escape is handled here, on the input, and not only by the backdrop's
+  # phx-window-keydown: the input is autofocused, and a keydown consumed by
+  # the focused element's own binding never reaches the window one. (The
+  # input also carries no phx-debounce — LiveView swallows Escape on a
+  # debounced input to cancel the pending change.)
+  def handle_event("key", %{"key" => "Escape"}, socket), do: {:noreply, close(socket)}
+  def handle_event("key", %{"key" => "ArrowDown"}, socket), do: {:noreply, move(socket, 1)}
+  def handle_event("key", %{"key" => "ArrowUp"}, socket), do: {:noreply, move(socket, -1)}
+  def handle_event("key", _params, socket), do: {:noreply, socket}
+
+  def handle_event("go", _params, socket) do
+    case Enum.at(entries(socket.assigns), socket.assigns.cursor) do
+      nil ->
+        {:noreply, socket}
+
+      entry ->
+        # Mouse clicks are recorded by the hook straight from the anchor;
+        # keyboard selection never touches one, so echo it back instead.
+        socket = close(socket)
+
+        socket =
+          if entry.record?,
+            do: push_event(socket, "palette:record", Map.take(entry, [:label, :meta, :path])),
+            else: socket
+
+        {:noreply, push_navigate(socket, to: entry.path)}
+    end
+  end
+
+  # Recents come from the browser, so they are input, not state: keep only
+  # rows that point somewhere inside this site's admin.
+  def handle_event("recents", %{"items" => items}, socket) when is_list(items) do
+    {:noreply, assign(socket, recents: Enum.filter(items, &own_path?(&1, socket.assigns.site)))}
+  end
+
+  def handle_event("recents", _params, socket), do: {:noreply, socket}
+
+  defp own_path?(%{"path" => path}, site) when is_binary(path),
+    do: String.starts_with?(path, "/#{site.slug}/")
+
+  defp own_path?(_item, _site), do: false
+
+  defp close(socket), do: assign(socket, open?: false)
+
+  # Always open on a clean slate: a palette that reopens showing the last
+  # search is a palette you have to clear before you can use it.
+  defp reset(socket),
+    do: assign(socket, open?: false, query: "", results: Search.search(nil, ""), cursor: 0)
+
+  defp move(socket, delta) do
+    case length(entries(socket.assigns)) do
+      0 -> socket
+      count -> assign(socket, cursor: Integer.mod(socket.assigns.cursor + delta, count))
+    end
+  end
+
+  # ---- rows ----
+
+  # Things that create something.
+  defp actions(site),
+    do: [
+      {"New post", ~p"/#{site.slug}/posts/new"},
+      {"New page", ~p"/#{site.slug}/pages/new"},
+      # Opens the upload dialog on arrival rather than landing beside it.
+      {"New upload", ~p"/#{site.slug}/uploads?new=1"}
+    ]
+
+  # Every destination in the sidebar, so the palette is a way to get around
+  # and not only a way to find content. "View site" is left out: it is an
+  # external link, which `.link navigate` cannot do.
+  defp destinations(site),
+    do: [
+      {"Overview", ~p"/#{site.slug}"},
+      {"Checklist", ~p"/#{site.slug}/checklist"},
+      {"Posts", ~p"/#{site.slug}/posts"},
+      {"Pages", ~p"/#{site.slug}/pages"},
+      {"Uploads", ~p"/#{site.slug}/uploads"},
+      {"Theme", ~p"/#{site.slug}/theme"},
+      {"Users", ~p"/#{site.slug}/users"},
+      {"Settings", ~p"/#{site.slug}/settings"},
+      {"All sites", ~p"/sites"}
+    ]
+
+  @doc false
+  def command_labels(site), do: Enum.map(actions(site) ++ destinations(site), &elem(&1, 0))
+
+  defp match(pairs, query) do
+    term = query |> String.trim() |> String.downcase()
+
+    pairs
+    |> Enum.filter(fn {label, _path} ->
+      term == "" or String.contains?(String.downcase(label), term)
+    end)
+    # `record?: false` — commands and destinations are always on screen with
+    # an empty query, so remembering them would just duplicate the row below.
+    |> Enum.map(fn {label, path} -> %{label: label, meta: "", path: path, record?: false} end)
+  end
+
+  # Groups in render order. The cursor indexes the flattened list, so this is
+  # the single source of truth for both what is drawn and what Enter opens.
+  defp groups(assigns) do
+    %{results: results, site: site, query: query, recents: recents} = assigns
+
+    # An idle palette shows where you have been, nothing else. Commands and
+    # destinations are a search away rather than a wall to read past.
+    if String.trim(query) == "" do
+      [{"Recent", Enum.map(recents, &recent_entry/1)}]
+    else
+      [
+        {"Commands", match(actions(site), query)},
+        {"Go to", match(destinations(site), query)},
+        {"Posts", Enum.map(results.posts, &entry(:post, &1, site))},
+        {"Pages", Enum.map(results.pages, &entry(:page, &1, site))},
+        {"Uploads", Enum.map(results.uploads, &entry(:upload, &1, site))}
+      ]
+    end
+    |> Enum.reject(fn {_title, entries} -> entries == [] end)
+  end
+
+  defp entries(assigns), do: assigns |> groups() |> Enum.flat_map(fn {_t, es} -> es end)
+
+  # Recents are re-recorded on use, so opening one bumps it back to the top.
+  defp recent_entry(%{"label" => label} = item),
+    do: %{
+      label: label,
+      meta: Map.get(item, "meta") || "",
+      path: Map.fetch!(item, "path"),
+      record?: true
+    }
+
+  defp entry(:post, post, site),
+    do: %{
+      label: post.title,
+      meta: if(post.published, do: "Published", else: "Draft"),
+      path: ~p"/#{site.slug}/posts/#{post.id}/edit",
+      record?: true
+    }
+
+  defp entry(:page, page, site),
+    do: %{
+      label: page.title,
+      meta: "/#{page.slug}",
+      path: ~p"/#{site.slug}/pages/#{page.id}/edit",
+      record?: true
+    }
+
+  defp entry(:upload, upload, site),
+    do: %{
+      label: upload.filename,
+      meta: format_bytes(upload.byte_size),
+      path: ~p"/#{site.slug}/uploads/#{upload.id}",
+      record?: true
+    }
+
+  defp format_bytes(b) when b < 1024, do: "#{b} B"
+  defp format_bytes(b) when b < 1024 * 1024, do: "#{Float.round(b / 1024, 1)} KB"
+  defp format_bytes(b), do: "#{Float.round(b / 1024 / 1024, 1)} MB"
+
+  # Pair every group with the flat index its first row occupies, so a row can
+  # tell whether it is the one the cursor is on.
+  defp indexed_groups(assigns) do
+    assigns
+    |> groups()
+    |> Enum.map_reduce(0, fn {title, entries}, offset ->
+      {{title, Enum.with_index(entries, offset)}, offset + length(entries)}
+    end)
+    |> elem(0)
+  end
+
+  @impl true
+  def render(assigns) do
+    assigns = assign(assigns, :indexed_groups, indexed_groups(assigns))
+
+    ~H"""
+    <%!-- phx-target so the hook's pushEventTo reaches this component rather
+          than the host LiveView, which knows nothing about recents. --%>
+    <div id={@id} phx-hook="CommandPalette" phx-target={@myself}>
+      <%!-- Hidden trigger: app.js clicks this on Cmd/Ctrl+K. Keeping the
+            opening in the same data-shortcut system as save/publish/new
+            means the palette needs no bespoke JS of its own. --%>
+      <button
+        type="button"
+        data-shortcut="palette"
+        phx-click="toggle"
+        phx-target={@myself}
+        class="visually-hidden"
+        tabindex="-1"
+        aria-label="Open search"
+      >
+      </button>
+
+      <div
+        :if={@open?}
+        class="dialog-backdrop palette-backdrop"
+        phx-window-keydown="close"
+        phx-key="Escape"
+        phx-target={@myself}
+      >
+        <button
+          type="button"
+          phx-click="close"
+          phx-target={@myself}
+          class="dialog-close-overlay"
+          aria-label="Close"
+          tabindex="-1"
+        >
+        </button>
+
+        <div class="dialog palette">
+          <form phx-change="search" phx-submit="go" phx-target={@myself} class="palette-form">
+            <input
+              type="text"
+              name="query"
+              value={@query}
+              placeholder="Search posts, pages and uploads…"
+              autocomplete="off"
+              phx-keydown="key"
+              phx-target={@myself}
+              phx-mounted={JS.focus()}
+              class="palette-input"
+              aria-label="Search this site"
+            />
+          </form>
+
+          <div :if={@indexed_groups == [] and @query != ""} class="palette-empty">
+            No matches for “{@query}”.
+          </div>
+
+          <div :if={@indexed_groups == [] and @query == ""} class="palette-empty">
+            Search posts, pages and uploads, or type a command.
+          </div>
+
+          <div :if={@indexed_groups != []} class="palette-results">
+            <section :for={{title, entries} <- @indexed_groups} class="palette-group">
+              <h3 class="palette-group-title">{title}</h3>
+              <ul>
+                <li :for={{entry, i} <- entries}>
+                  <.link
+                    navigate={entry.path}
+                    class={["palette-item", @cursor == i && "is-active"]}
+                    aria-current={@cursor == i && "true"}
+                    data-label={entry.label}
+                    data-meta={entry.meta}
+                    data-record={entry.record? && "1"}
+                  >
+                    <span class="palette-item-label">{entry.label}</span>
+                    <span class="palette-item-meta">{entry.meta}</span>
+                  </.link>
+                </li>
+              </ul>
+            </section>
+          </div>
+
+          <footer class="palette-footer">
+            <span><kbd>↑</kbd><kbd>↓</kbd> to move</span>
+            <span><kbd>↵</kbd> to open</span>
+            <span><kbd>esc</kbd> to close</span>
+          </footer>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/masthead_web/live/admin/components.ex
+++ b/lib/masthead_web/live/admin/components.ex
@@ -219,6 +219,15 @@ defmodule MastheadWeb.AdminLive.Components do
 
         {render_slot(@inner_block)}
       </main>
+
+      <%!-- Site-scoped, so it only exists where there is content to search.
+            Self-contained: no host LiveView wiring needed. --%>
+      <.live_component
+        :if={@site}
+        module={MastheadWeb.AdminLive.CommandPalette}
+        id="command-palette"
+        site={@site}
+      />
     </div>
     """
   end

--- a/lib/masthead_web/live/admin/upload_index.ex
+++ b/lib/masthead_web/live/admin/upload_index.ex
@@ -29,9 +29,15 @@ defmodule MastheadWeb.AdminLive.UploadIndex do
 
   @impl true
   def handle_params(params, _uri, socket) do
+    # `?new=1` opens the upload dialog on arrival, so the command palette's
+    # "New upload" lands on the thing it names rather than next to it.
     {:noreply,
      socket
-     |> assign(search: params["q"] || "", type_filter: parse_filter(params))
+     |> assign(
+       search: params["q"] || "",
+       type_filter: parse_filter(params),
+       modal_open?: params["new"] == "1" or socket.assigns[:modal_open?] == true
+     )
      |> reload_uploads()}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.20.0",
+      version: "2.21.0",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/masthead/search_test.exs
+++ b/test/masthead/search_test.exs
@@ -1,0 +1,114 @@
+defmodule Masthead.SearchTest do
+  use Masthead.DataCase
+
+  alias Masthead.{Accounts, Content, Search, Sites, Uploads}
+
+  setup do
+    {:ok, user} =
+      Accounts.register_user(%{
+        "email" => "se-#{System.unique_integer([:positive])}@example.com",
+        "password" => "password1234"
+      })
+
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "se#{System.unique_integer([:positive])}",
+        "name" => "Search Site",
+        "owner_id" => user.id
+      })
+
+    %{site: site}
+  end
+
+  defp create_upload(site, filename) do
+    tmp = Path.join(System.tmp_dir!(), "se-#{System.unique_integer([:positive])}.png")
+    File.write!(tmp, "bytes")
+
+    {:ok, upload} =
+      Uploads.store_image(site, %{filename: filename, content_type: "image/png", path: tmp})
+
+    File.rm(tmp)
+    upload
+  end
+
+  describe "search/3" do
+    test "finds matches across all three kinds at once", %{site: site} do
+      {:ok, _} = Content.create_post(site.id, %{"title" => "Harvest report"})
+      {:ok, _} = Content.create_page(site.id, %{"title" => "Harvest", "format" => "markdown"})
+      create_upload(site, "harvest-photo.png")
+
+      results = Search.search(site.id, "harvest")
+
+      assert [%{title: "Harvest report"}] = results.posts
+      assert [%{title: "Harvest"}] = results.pages
+      assert [%{filename: "harvest-photo.png"}] = results.uploads
+      assert Search.count(results) == 3
+      refute Search.empty?(results)
+    end
+
+    test "matches case-insensitively", %{site: site} do
+      {:ok, _} = Content.create_post(site.id, %{"title" => "Harvest report"})
+
+      assert [_] = Search.search(site.id, "HARVEST").posts
+    end
+
+    test "a term that matches nothing returns empty groups", %{site: site} do
+      {:ok, _} = Content.create_post(site.id, %{"title" => "Harvest report"})
+
+      results = Search.search(site.id, "nothing-matches")
+
+      assert Search.empty?(results)
+      assert Search.count(results) == 0
+    end
+
+    test "a blank term matches nothing rather than everything", %{site: site} do
+      {:ok, _} = Content.create_post(site.id, %{"title" => "Harvest report"})
+      create_upload(site, "photo.png")
+
+      for term <- ["", "   ", nil] do
+        assert Search.empty?(Search.search(site.id, term)),
+               "expected #{inspect(term)} to match nothing"
+      end
+    end
+
+    test "each kind is capped independently", %{site: site} do
+      for n <- 1..8, do: {:ok, _} = Content.create_post(site.id, %{"title" => "note #{n}"})
+      for n <- 1..8, do: create_upload(site, "note-#{n}.png")
+      {:ok, _} = Content.create_page(site.id, %{"title" => "note page", "format" => "markdown"})
+
+      results = Search.search(site.id, "note", limit: 5)
+
+      # A flood of uploads must not crowd out the single matching page.
+      assert length(results.posts) == 5
+      assert length(results.uploads) == 5
+      assert length(results.pages) == 1
+    end
+
+    test "is scoped to the site", %{site: site} do
+      {:ok, other_user} =
+        Accounts.register_user(%{
+          "email" => "se2-#{System.unique_integer([:positive])}@example.com",
+          "password" => "password1234"
+        })
+
+      {:ok, other_site} =
+        Sites.create_site(%{
+          "slug" => "se2#{System.unique_integer([:positive])}",
+          "name" => "Other",
+          "owner_id" => other_user.id
+        })
+
+      {:ok, _} = Content.create_post(other_site.id, %{"title" => "Secret roadmap"})
+
+      assert Search.empty?(Search.search(site.id, "roadmap"))
+      assert [_] = Search.search(other_site.id, "roadmap").posts
+    end
+
+    test "finds drafts as well as published content", %{site: site} do
+      {:ok, draft} = Content.create_post(site.id, %{"title" => "Draft idea"})
+      refute draft.published
+
+      assert [_] = Search.search(site.id, "draft idea").posts
+    end
+  end
+end

--- a/test/masthead_web/command_palette_live_test.exs
+++ b/test/masthead_web/command_palette_live_test.exs
@@ -1,0 +1,464 @@
+defmodule MastheadWeb.CommandPaletteLiveTest do
+  use MastheadWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Masthead.{Accounts, Content, Sites, Uploads}
+
+  setup do
+    {:ok, user} =
+      Accounts.register_user(%{
+        "email" => "cp-#{System.unique_integer([:positive])}@example.com",
+        "password" => "password1234"
+      })
+
+    {:ok, site} =
+      Sites.create_site(%{
+        "slug" => "cp#{System.unique_integer([:positive])}",
+        "name" => "CP Test",
+        "owner_id" => user.id
+      })
+
+    {:ok, post} = Content.create_post(site.id, %{"title" => "Harvest report"})
+
+    {:ok, page} =
+      Content.create_page(site.id, %{"title" => "Harvest guide", "format" => "markdown"})
+
+    upload = create_upload(site, "harvest-photo.png")
+
+    conn =
+      build_conn()
+      |> Plug.Test.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_id, user.id)
+
+    %{conn: conn, site: site, post: post, page: page, upload: upload}
+  end
+
+  defp create_upload(site, filename) do
+    tmp = Path.join(System.tmp_dir!(), "cp-#{System.unique_integer([:positive])}.png")
+    File.write!(tmp, "bytes")
+
+    {:ok, upload} =
+      Uploads.store_image(site, %{filename: filename, content_type: "image/png", path: tmp})
+
+    File.rm(tmp)
+    upload
+  end
+
+  # Every helper returns the palette's own markup, not the whole page: the
+  # list behind the modal contains the same titles, so page-wide assertions
+  # would pass (or fail) for the wrong reason.
+  defp palette(lv), do: render(element(lv, "#command-palette"))
+
+  defp open(lv) do
+    lv |> element(~s(#command-palette [data-shortcut="palette"])) |> render_click()
+    palette(lv)
+  end
+
+  defp type(lv, query) do
+    lv |> form("#command-palette form", %{"query" => query}) |> render_change()
+    palette(lv)
+  end
+
+  defp press(lv, key) do
+    lv |> element("#command-palette .palette-input") |> render_keydown(%{"key" => key})
+    palette(lv)
+  end
+
+  test "the palette is present but closed on load", %{conn: conn, site: site} do
+    {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/posts")
+
+    # The trigger app.js clicks on Cmd/Ctrl+K.
+    assert html =~ ~s(data-shortcut="palette")
+    refute html =~ "palette-input"
+  end
+
+  test "the trigger opens it", %{conn: conn, site: site} do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+
+    html = open(lv)
+
+    assert html =~ "palette-input"
+    assert html =~ "Search this site"
+  end
+
+  test "typing finds matches across all three kinds", %{conn: conn, site: site} do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+    open(lv)
+
+    html = type(lv, "harvest")
+
+    assert html =~ "Harvest report"
+    assert html =~ "Harvest guide"
+    assert html =~ "harvest-photo.png"
+    assert html =~ "Posts"
+    assert html =~ "Pages"
+    assert html =~ "Uploads"
+  end
+
+  test "results link to the right places", %{
+    conn: conn,
+    site: site,
+    post: post,
+    page: page,
+    upload: upload
+  } do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+    open(lv)
+
+    html = type(lv, "harvest")
+
+    assert html =~ ~p"/#{site.slug}/posts/#{post.id}/edit"
+    assert html =~ ~p"/#{site.slug}/pages/#{page.id}/edit"
+    assert html =~ ~p"/#{site.slug}/uploads/#{upload.id}"
+  end
+
+  test "an idle palette is empty apart from an invitation", %{conn: conn, site: site} do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+    html = open(lv)
+
+    assert html =~ "Search posts, pages and uploads, or type a command."
+
+    # Nothing to read past: no commands, no destinations, no content.
+    refute html =~ "Commands"
+    refute html =~ "Go to"
+    refute html =~ "Harvest report"
+    refute html =~ "harvest-photo.png"
+  end
+
+  test "commands and destinations appear once you search", %{conn: conn, site: site} do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+    open(lv)
+
+    for label <- MastheadWeb.AdminLive.CommandPalette.command_labels(site) do
+      assert type(lv, label) =~ label, "expected #{inspect(label)} to be findable"
+    end
+  end
+
+  describe "commands" do
+    test "each one links where it says", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      assert type(lv, "new post") =~ ~p"/#{site.slug}/posts/new"
+      assert type(lv, "new page") =~ ~p"/#{site.slug}/pages/new"
+      # "New upload" opens the dialog on arrival rather than just landing
+      # next to it.
+      assert type(lv, "new upload") =~ "/#{site.slug}/uploads?new=1"
+    end
+
+    test "they filter by name as you type", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      html = type(lv, "new p")
+
+      assert html =~ "New post"
+      assert html =~ "New page"
+      refute html =~ "New upload"
+      refute html =~ "Settings"
+    end
+
+    test "a content search that matches no command hides the group", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      html = type(lv, "harvest")
+
+      assert html =~ "Harvest report"
+      refute html =~ "Commands"
+      refute html =~ "Go to"
+    end
+
+    test "every sidebar destination is reachable", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      for {label, path} <- [
+            {"Overview", ~p"/#{site.slug}"},
+            {"Checklist", ~p"/#{site.slug}/checklist"},
+            {"Posts", ~p"/#{site.slug}/posts"},
+            {"Pages", ~p"/#{site.slug}/pages"},
+            {"Uploads", ~p"/#{site.slug}/uploads"},
+            {"Theme", ~p"/#{site.slug}/theme"},
+            {"Users", ~p"/#{site.slug}/users"},
+            {"Settings", ~p"/#{site.slug}/settings"},
+            {"All sites", ~p"/sites"}
+          ] do
+        html = type(lv, label)
+        assert html =~ "Go to"
+        assert html =~ ~s(href="#{path}"), "expected #{inspect(label)} to link to #{path}"
+      end
+    end
+
+    test "destinations filter by name too", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      html = type(lv, "theme")
+
+      assert html =~ "Theme"
+      refute html =~ "Checklist"
+    end
+
+    test "navigating to a destination works", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      assert active_label(type(lv, "checklist")) == "Checklist"
+      lv |> form("#command-palette form") |> render_submit()
+
+      assert_redirect(lv, ~p"/#{site.slug}/checklist")
+    end
+
+    test "commands are reachable by keyboard like any other row", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      assert active_label(type(lv, "new post")) == "New post"
+
+      lv |> form("#command-palette form") |> render_submit()
+
+      assert_redirect(lv, ~p"/#{site.slug}/posts/new")
+    end
+
+    test "?new=1 opens the upload dialog on arrival", %{conn: conn, site: site} do
+      {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/uploads?new=1")
+
+      assert html =~ "New upload"
+      assert html =~ "dropzone"
+    end
+
+    test "the uploads page stays closed without it", %{conn: conn, site: site} do
+      {:ok, _lv, html} = live(conn, ~p"/#{site.slug}/uploads")
+
+      refute html =~ "dropzone"
+    end
+  end
+
+  describe "recents" do
+    # Stand in for the PaletteRecents hook, which reads localStorage and
+    # pushes what it finds.
+    defp send_recents(lv, items) do
+      lv
+      |> element("#command-palette")
+      |> render_hook("recents", %{"items" => items})
+
+      palette(lv)
+    end
+
+    test "recent items show above the commands on an empty query", %{
+      conn: conn,
+      site: site,
+      post: post
+    } do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      html =
+        send_recents(lv, [
+          %{
+            "label" => "Harvest report",
+            "meta" => "Draft",
+            "path" => "/#{site.slug}/posts/#{post.id}/edit"
+          }
+        ])
+
+      assert html =~ "Recent"
+      assert html =~ "Harvest report"
+      # Recents are all an idle palette shows, so the cursor starts on one.
+      assert active_label(html) == "Harvest report"
+      refute html =~ "Commands"
+    end
+
+    test "recents are hidden once you type", %{conn: conn, site: site, post: post} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      send_recents(lv, [
+        %{
+          "label" => "Recently opened",
+          "meta" => "",
+          "path" => "/#{site.slug}/posts/#{post.id}/edit"
+        }
+      ])
+
+      html = type(lv, "harvest")
+
+      refute html =~ "Recent</h3>"
+      refute html =~ "Recently opened"
+    end
+
+    test "paths outside this site are dropped", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      # localStorage is user-controlled input, not trusted state.
+      html =
+        send_recents(lv, [
+          %{"label" => "Evil", "meta" => "", "path" => "https://evil.example/steal"},
+          %{"label" => "Other site", "meta" => "", "path" => "/some-other-site/posts/1/edit"},
+          %{"label" => "Protocol", "meta" => "", "path" => "javascript:alert(1)"}
+        ])
+
+      refute html =~ "Evil"
+      refute html =~ "Other site"
+      refute html =~ "Protocol"
+      refute html =~ "evil.example"
+      refute html =~ "Recent</h3>"
+    end
+
+    test "malformed payloads are ignored", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      lv |> element("#command-palette") |> render_hook("recents", %{"items" => "not-a-list"})
+
+      # Still a working palette, just no recents.
+      assert palette(lv) =~ "Search posts, pages and uploads"
+      assert type(lv, "harvest") =~ "Harvest report"
+    end
+  end
+
+  test "a query with no matches says so", %{conn: conn, site: site} do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+    open(lv)
+
+    html = type(lv, "nothing-matches-this")
+
+    assert html =~ "No matches for"
+    refute html =~ "Harvest report"
+  end
+
+  test "reopening starts from a clean slate", %{conn: conn, site: site} do
+    {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+    open(lv)
+    assert type(lv, "harvest") =~ "Harvest report"
+
+    lv |> element(~s(#command-palette [phx-click="close"])) |> render_click()
+    html = open(lv)
+
+    # A palette that reopens on the last search is one you must clear first.
+    refute html =~ "Harvest report"
+  end
+
+  describe "closing" do
+    test "Escape from the search input closes it", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      assert open(lv) =~ "palette-input"
+
+      # Escape must be handled by the input's own binding: the input is
+      # autofocused, so a window-level binding alone never sees the key.
+      refute press(lv, "Escape") =~ "palette-input"
+    end
+
+    test "the shortcut toggles it shut again", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+
+      assert open(lv) =~ "palette-input"
+      # `open/1` clicks the same trigger app.js does on Cmd/Ctrl+K.
+      refute open(lv) =~ "palette-input"
+      assert open(lv) =~ "palette-input"
+    end
+
+    test "toggling shut and open again clears the previous search", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+      assert type(lv, "harvest") =~ "Harvest report"
+
+      open(lv)
+      refute open(lv) =~ "Harvest report"
+    end
+
+    test "clicking the backdrop closes it", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      lv |> element(~s(#command-palette [phx-click="close"])) |> render_click()
+
+      refute palette(lv) =~ "palette-input"
+    end
+  end
+
+  describe "keyboard navigation" do
+    test "the first result starts highlighted", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+
+      html = type(lv, "harvest")
+
+      # Exactly one row carries the cursor, and it's the first result.
+      assert count(html, "is-active") == 1
+      assert active_label(html) == "Harvest report"
+    end
+
+    test "arrow keys move the cursor and it wraps around", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+      type(lv, "harvest")
+
+      # Three results: post, page, upload. Down thrice returns to the start.
+      assert active_label(press(lv, "ArrowDown")) == "Harvest guide"
+      assert active_label(press(lv, "ArrowDown")) == "harvest-photo.png"
+      assert active_label(press(lv, "ArrowDown")) == "Harvest report"
+
+      # Up from the first wraps to the last.
+      assert active_label(press(lv, "ArrowUp")) == "harvest-photo.png"
+    end
+
+    test "other keys leave the cursor alone", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+      type(lv, "harvest")
+
+      assert active_label(press(lv, "ArrowDown")) == "Harvest guide"
+      assert active_label(press(lv, "a")) == "Harvest guide"
+    end
+
+    test "typing a new query resets the cursor to the top", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+      type(lv, "harvest")
+      assert active_label(press(lv, "ArrowDown")) == "Harvest guide"
+
+      assert active_label(type(lv, "harvest ")) == "Harvest report"
+    end
+
+    test "Enter opens the highlighted result", %{conn: conn, site: site, page: page} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+      type(lv, "harvest")
+      press(lv, "ArrowDown")
+
+      lv |> form("#command-palette form") |> render_submit()
+
+      assert_redirect(lv, ~p"/#{site.slug}/pages/#{page.id}/edit")
+    end
+
+    test "Enter with no results does nothing", %{conn: conn, site: site} do
+      {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/posts")
+      open(lv)
+      type(lv, "nothing-matches-this")
+
+      html = lv |> form("#command-palette form") |> render_submit()
+
+      assert html =~ "No matches for"
+    end
+  end
+
+  test "pages without a site get no palette", %{conn: conn} do
+    {:ok, _lv, html} = live(conn, ~p"/sites")
+
+    refute html =~ ~s(data-shortcut="palette")
+  end
+
+  defp count(html, needle), do: html |> String.split(needle) |> length() |> Kernel.-(1)
+
+  # The label of the row currently carrying the keyboard cursor.
+  defp active_label(html) do
+    case Regex.run(~r/is-active[^>]*>.*?palette-item-label[^>]*>([^<]+)</s, html) do
+      [_, label] -> String.trim(label)
+      nil -> nil
+    end
+  end
+end


### PR DESCRIPTION
A single modal to search a site's content and get around it, rendered once by the admin shell so every site-scoped page has it without wiring.

`Masthead.Search` queries the three kinds and caps each independently rather than merging them in SQL: a union would have to rank titles against filenames to decide what falls off the end, and capping per kind means a flood of matching uploads can't crowd out the one matching page. A blank term matches nothing rather than everything.

The palette is self-contained — it runs its own search and navigates itself, so host LiveViews need no handle_info. Opening reuses the existing `data-shortcut` system: app.js clicks a hidden trigger, the same way save/publish/new already work, rather than inventing a second mechanism. Cmd/Ctrl+K toggles, so the key that opens it also shuts it.

Idle, it shows only recently opened items. Typing searches content and filters the create-commands and every sidebar destination by name. "New upload" carries `?new=1`, which opens the upload dialog on arrival so the command lands on the thing it names.

Recents live in localStorage — per-browser, nothing worth a table, and a round trip on every open would cost more than the feature is worth. What comes back is treated as input, not state: the server drops any path that isn't inside the current site before rendering it as a link.

Two details worth recording, both found in the browser rather than in tests:

  * Escape is handled by the input's own binding, not just the backdrop's phx-window-keydown. The input is autofocused, and a key consumed by the focused element never reaches the window binding.
  * The input carries no phx-debounce. LiveView swallows Escape on a debounced input to cancel the pending change, so the debounce and the close were mutually exclusive.

The keyboard cursor lives on the server, so the hook scrolls the active row back into view after each patch.

Version 2.21.0 — additive.


Claude-Session: https://claude.ai/code/session_012btkx3DQWEJrDfnWuQ14Q8