### PR TITLE
feat: admin row menu, gifted licenses, license filters

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1060,7 +1060,16 @@ button.danger:hover { filter: brightness(0.92); }
   color: inherit;
 }
 .card-list li a:hover { text-decoration: none; }
-.card-list li strong { font-size: 1.05rem; font-weight: 600; letter-spacing: -0.015em; color: var(--fg); }
+.card-list li strong {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--fg);
+  padding-right: 5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .card-list li .muted {
   font-size: 0.8rem;
   font-family: ui-monospace, Menlo, monospace;
@@ -1149,6 +1158,15 @@ button.danger:hover { filter: brightness(0.92); }
   font-size: 0.78rem;
   font-family: ui-monospace, Menlo, monospace;
 }
+
+/* A table whose rows carry a kebab menu cannot clip its own overflow, or
+   the panel is cut off at the table edge. The corner radii that
+   `overflow: hidden` was providing are restored on the corner cells. */
+.table-menus { overflow: visible; }
+.table-menus thead tr:first-child th:first-child { border-top-left-radius: 14px; }
+.table-menus thead tr:first-child th:last-child { border-top-right-radius: 14px; }
+.table-menus tbody tr:last-child td:first-child { border-bottom-left-radius: 14px; }
+.table-menus tbody tr:last-child td:last-child { border-bottom-right-radius: 14px; }
 
 /* Right-aligned cluster of row action buttons (e.g. Edit / Delete). */
 .row-actions { display: inline-flex; align-items: center; gap: 0.4rem; }
@@ -1359,6 +1377,12 @@ button.danger:hover { filter: brightness(0.92); }
    wider tables to scroll on narrow viewports and lays out the row's
    action buttons in a right-aligned cluster. */
 .admin-table-wrap { overflow-x: auto; }
+/* The row menu is absolutely positioned inside this box, and overflow-x on
+   one axis forces the other to clip too. Wide screens do not need the
+   horizontal scroll, so drop it there and let the menu escape. */
+@media (min-width: 1024px) {
+  .admin-table-wrap { overflow: visible; }
+}
 .admin-row-actions {
   display: flex;
   gap: 0.4rem;
@@ -1366,6 +1390,72 @@ button.danger:hover { filter: brightness(0.92); }
   align-items: center;
   justify-content: flex-end;
 }
+/* Row kebab menu — collapses per-row admin actions behind one trigger. */
+.row-menu { position: relative; display: inline-flex; }
+.row-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.row-menu-trigger:hover,
+.row-menu-trigger[aria-expanded="true"] {
+  background: var(--bg-soft);
+  border-color: var(--rule);
+  color: var(--fg);
+}
+.row-menu-trigger svg { width: 18px; height: 18px; }
+.row-menu-panel {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  z-index: 30;
+  min-width: 12rem;
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  background: var(--card);
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  box-shadow: var(--shadow-lg);
+}
+.row-menu-panel > a,
+.row-menu-panel > button {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  font: inherit;
+  font-size: 0.88rem;
+  text-align: left;
+  color: var(--fg);
+  cursor: pointer;
+}
+.row-menu-panel > a:hover,
+.row-menu-panel > button:hover {
+  background: var(--bg-soft);
+  text-decoration: none;
+  color: var(--fg);
+}
+.row-menu-panel > .is-danger { color: var(--danger); }
+.row-menu-panel > .is-danger:hover { background: var(--danger-soft); color: var(--danger); }
+.row-menu-panel hr {
+  margin: 0.35rem 0;
+  border: 0;
+  border-top: 1px solid var(--rule);
+}
+
 /* Toolbar above each admin table: filter buttons on the left, search on
    the right, with a cap hint underneath when the list is truncated. */
 .admin-toolbar {
@@ -2408,6 +2498,7 @@ button.danger:hover { filter: brightness(0.92); }
 }
 .dialog-form input[type="text"],
 .dialog-form input[type="email"],
+.dialog-form input[type="number"],
 .dialog-form textarea {
   padding: 0.55rem 0.75rem;
   border: 1px solid var(--rule);
@@ -2420,6 +2511,7 @@ button.danger:hover { filter: brightness(0.92); }
 }
 .dialog-form input[type="text"]:focus,
 .dialog-form input[type="email"]:focus,
+.dialog-form input[type="number"]:focus,
 .dialog-form textarea:focus {
   outline: 2px solid var(--accent);
   outline-offset: -1px;
@@ -4846,4 +4938,17 @@ button.danger:hover { filter: brightness(0.92); }
 }
 @media (prefers-reduced-motion: reduce) {
   .install-card .btn-installed { animation: none; }
+}
+
+/* Below the desktop breakpoint the table still scrolls, so the row menu
+   cannot rely on absolute positioning: fixed escapes the clip entirely. */
+@media (max-width: 1023px) {
+  .row-menu-panel {
+    position: fixed;
+    top: auto;
+    bottom: 1rem;
+    left: 1rem;
+    right: 1rem;
+    min-width: 0;
+  }
 }

--- a/lib/masthead/licenses.ex
+++ b/lib/masthead/licenses.ex
@@ -161,6 +161,29 @@ defmodule Masthead.Licenses do
   defp status_for(%{cancels_at_period_end: true}), do: "canceling"
   defp status_for(%{type: :active}), do: "active"
 
+  @doc """
+  Extends a site's license by `months` without a provider subscription.
+
+  Adds onto the existing expiry when the site is already paid, so gifting a
+  paying customer tops them up rather than cutting them short. Calendar
+  months, not 30-day blocks.
+  """
+  def gift(%Site{} = site, months) when is_integer(months) and months > 0 do
+    base = if paid?(site), do: site.license_expires_at, else: DateTime.utc_now()
+
+    site
+    |> Ecto.Changeset.change(
+      license_status: "active",
+      license_plan: site.license_plan || "gift",
+      license_expires_at: base |> DateTime.shift(month: months) |> DateTime.truncate(:second)
+    )
+    |> Repo.update()
+    |> announce()
+  end
+
+  @doc "True when the site has a provider customer, so the billing portal can open."
+  def billable?(%Site{payment_customer_id: id}), do: not is_nil(id)
+
   @doc "Licenses `site` until `expires_at` without touching a provider. Seeds and tests."
   def grant(%Site{} = site, plan \\ "yearly", expires_at \\ nil) do
     expires_at =

--- a/lib/masthead/payments.ex
+++ b/lib/masthead/payments.ex
@@ -282,6 +282,9 @@ defmodule Masthead.Payments.Stub do
   defp expires_at(_value), do: nil
 
   defp stub(key, default) do
-    {:ok, Map.get(Application.get_env(:masthead, :payments_stub, %{}), key, default)}
+    case Map.get(Application.get_env(:masthead, :payments_stub, %{}), key, default) do
+      {:error, _reason} = error -> error
+      url -> {:ok, url}
+    end
   end
 end

--- a/lib/masthead/sites.ex
+++ b/lib/masthead/sites.ex
@@ -471,11 +471,30 @@ defmodule Masthead.Sites do
   end
 
   defp apply_filter(query, filter) do
+    now = DateTime.utc_now()
+
     case filter do
-      :disabled -> from s in query, where: not is_nil(s.disabled_at)
-      :deleted -> from s in query, where: not is_nil(s.deleted_at)
-      :enabled -> from s in query, where: is_nil(s.disabled_at) and is_nil(s.deleted_at)
-      _ -> query
+      :disabled ->
+        from s in query, where: not is_nil(s.disabled_at)
+
+      :deleted ->
+        from s in query, where: not is_nil(s.deleted_at)
+
+      :enabled ->
+        from s in query, where: is_nil(s.disabled_at) and is_nil(s.deleted_at)
+
+      :paid ->
+        from s in query,
+          where: s.license_status in ~w(active canceling) and s.license_expires_at > ^now
+
+      :free ->
+        from s in query,
+          where:
+            is_nil(s.license_status) or s.license_status not in ~w(active canceling) or
+              is_nil(s.license_expires_at) or s.license_expires_at <= ^now
+
+      _ ->
+        query
     end
   end
 

--- a/lib/masthead_web/live/admin/console.ex
+++ b/lib/masthead_web/live/admin/console.ex
@@ -4,7 +4,7 @@ defmodule MastheadWeb.AdminLive.Console do
 
   import MastheadWeb.AdminLive.Components
 
-  alias Masthead.{Accounts, Actions, Sites, Themes}
+  alias Masthead.{Accounts, Actions, Licenses, Sites, Themes}
 
   @default_filters %{users: :all, sites: :enabled, themes: :public}
 
@@ -17,6 +17,9 @@ defmodule MastheadWeb.AdminLive.Console do
        tab: :users,
        action_modal?: false,
        action_site: nil,
+       gift_modal?: false,
+       gift_site: nil,
+       open_menu: nil,
        users_filter: @default_filters.users,
        users_search: "",
        sites_filter: @default_filters.sites,
@@ -73,7 +76,13 @@ defmodule MastheadWeb.AdminLive.Console do
     ]
 
   defp filter_options(:sites),
-    do: [{:enabled, "Enabled"}, {:disabled, "Disabled"}, {:deleted, "Deleted"}]
+    do: [
+      {:enabled, "Enabled"},
+      {:disabled, "Disabled"},
+      {:deleted, "Deleted"},
+      {:paid, "Paid"},
+      {:free, "Free"}
+    ]
 
   defp filter_options(:themes),
     do: [
@@ -122,26 +131,74 @@ defmodule MastheadWeb.AdminLive.Console do
 
   def handle_event("disable_site", %{"id" => id}, socket) do
     {:ok, _} = id |> Sites.get_site!() |> Sites.disable_site()
-    {:noreply, socket |> put_flash(:info, "Site disabled.") |> load_data()}
+
+    {:noreply,
+     socket |> assign(open_menu: nil) |> put_flash(:info, "Site disabled.") |> load_data()}
   end
 
   def handle_event("enable_site", %{"id" => id}, socket) do
     {:ok, _} = id |> Sites.get_site!() |> Sites.enable_site()
-    {:noreply, socket |> put_flash(:info, "Site enabled.") |> load_data()}
+
+    {:noreply,
+     socket |> assign(open_menu: nil) |> put_flash(:info, "Site enabled.") |> load_data()}
   end
 
   def handle_event("delete_site", %{"id" => id}, socket) do
     {:ok, _} = id |> Sites.get_site!() |> Sites.soft_delete_site()
-    {:noreply, socket |> put_flash(:info, "Site deleted (recoverable).") |> load_data()}
+
+    {:noreply,
+     socket
+     |> assign(open_menu: nil)
+     |> put_flash(:info, "Site deleted (recoverable).")
+     |> load_data()}
   end
 
   def handle_event("restore_site", %{"id" => id}, socket) do
     {:ok, _} = id |> Sites.get_site!() |> Sites.restore_site()
-    {:noreply, socket |> put_flash(:info, "Site restored.") |> load_data()}
+
+    {:noreply,
+     socket |> assign(open_menu: nil) |> put_flash(:info, "Site restored.") |> load_data()}
+  end
+
+  def handle_event("toggle_menu", %{"id" => id}, socket) do
+    id = String.to_integer(id)
+    open = if socket.assigns.open_menu == id, do: nil, else: id
+    {:noreply, assign(socket, open_menu: open)}
+  end
+
+  def handle_event("close_menu", _params, socket) do
+    {:noreply, assign(socket, open_menu: nil)}
+  end
+
+  def handle_event("open_gift_modal", %{"site_id" => id}, socket) do
+    {:noreply, assign(socket, gift_modal?: true, gift_site: Sites.get_site!(id), open_menu: nil)}
+  end
+
+  def handle_event("close_gift_modal", _params, socket) do
+    {:noreply, assign(socket, gift_modal?: false, gift_site: nil)}
+  end
+
+  def handle_event("gift_pro", %{"months" => months}, socket) do
+    site = socket.assigns.gift_site
+
+    case Integer.parse(months) do
+      {months, ""} when months > 0 and months <= 120 ->
+        {:ok, site} = Licenses.gift(site, months)
+
+        {:noreply,
+         socket
+         |> assign(gift_modal?: false, gift_site: nil)
+         |> put_flash(:info, "#{site.name} is licensed until #{gift_date(site)}.")
+         |> load_data()}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, "Enter a whole number of months between 1 and 120.")}
+    end
   end
 
   def handle_event("open_action_modal", %{"site_id" => id}, socket) do
-    {:noreply, assign(socket, action_modal?: true, action_site: Sites.get_site!(id))}
+    {:noreply,
+     assign(socket, action_modal?: true, action_site: Sites.get_site!(id), open_menu: nil)}
   end
 
   def handle_event("close_action_modal", _params, socket) do
@@ -284,7 +341,7 @@ defmodule MastheadWeb.AdminLive.Console do
           limit={list_limit()}
           truncated?={length(@sites) == list_limit()}
         />
-        <table class="table">
+        <table class="table table-menus">
           <thead>
             <tr>
               <th>Name</th>
@@ -292,7 +349,7 @@ defmodule MastheadWeb.AdminLive.Console do
               <th>Members</th>
               <th>Created</th>
               <th>Status</th>
-              <th>Add action</th>
+              <th>License</th>
               <th></th>
             </tr>
           </thead>
@@ -315,52 +372,85 @@ defmodule MastheadWeb.AdminLive.Console do
                 </span>
               </td>
               <td>
-                <button
-                  type="button"
-                  class="btn btn-sm"
-                  phx-click="open_action_modal"
-                  phx-value-site_id={s.id}
-                >
-                  + Action
-                </button>
+                <span class={["pill", Licenses.pill_class(s)]}>{Licenses.label(s)}</span>
               </td>
               <td class="admin-row-actions">
-                <.link :if={is_nil(s.deleted_at)} navigate={~p"/#{s.slug}"} class="btn btn-sm">
-                  Enter
-                </.link>
-                <button
-                  :if={is_nil(s.disabled_at) and is_nil(s.deleted_at)}
-                  class="btn btn-sm"
-                  phx-click="disable_site"
-                  phx-value-id={s.id}
-                >
-                  Disable
-                </button>
-                <button
-                  :if={not is_nil(s.disabled_at) and is_nil(s.deleted_at)}
-                  class="btn btn-sm"
-                  phx-click="enable_site"
-                  phx-value-id={s.id}
-                >
-                  Enable
-                </button>
-                <button
-                  :if={is_nil(s.deleted_at)}
-                  class="btn btn-sm btn-danger"
-                  phx-click="delete_site"
-                  phx-value-id={s.id}
-                  data-confirm={"Delete #{s.name}? It's recoverable from here."}
-                >
-                  Delete
-                </button>
-                <button
-                  :if={not is_nil(s.deleted_at)}
-                  class="btn btn-sm"
-                  phx-click="restore_site"
-                  phx-value-id={s.id}
-                >
-                  Restore
-                </button>
+                <div class="row-menu" phx-click-away={@open_menu == s.id && "close_menu"}>
+                  <button
+                    type="button"
+                    class="row-menu-trigger"
+                    phx-click="toggle_menu"
+                    phx-value-id={s.id}
+                    aria-haspopup="menu"
+                    aria-expanded={to_string(@open_menu == s.id)}
+                    aria-label={"Actions for #{s.name}"}
+                  >
+                    <.dots_icon />
+                  </button>
+
+                  <div :if={@open_menu == s.id} class="row-menu-panel" role="menu">
+                    <.link :if={is_nil(s.deleted_at)} navigate={~p"/#{s.slug}"} role="menuitem">
+                      Enter site
+                    </.link>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      phx-click="open_action_modal"
+                      phx-value-site_id={s.id}
+                    >
+                      Add action
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      phx-click="open_gift_modal"
+                      phx-value-site_id={s.id}
+                    >
+                      Gift Pro…
+                    </button>
+
+                    <hr />
+
+                    <button
+                      :if={is_nil(s.disabled_at) and is_nil(s.deleted_at)}
+                      type="button"
+                      role="menuitem"
+                      phx-click="disable_site"
+                      phx-value-id={s.id}
+                    >
+                      Disable
+                    </button>
+                    <button
+                      :if={not is_nil(s.disabled_at) and is_nil(s.deleted_at)}
+                      type="button"
+                      role="menuitem"
+                      phx-click="enable_site"
+                      phx-value-id={s.id}
+                    >
+                      Enable
+                    </button>
+                    <button
+                      :if={is_nil(s.deleted_at)}
+                      type="button"
+                      role="menuitem"
+                      class="is-danger"
+                      phx-click="delete_site"
+                      phx-value-id={s.id}
+                      data-confirm={"Delete #{s.name}? It's recoverable from here."}
+                    >
+                      Delete
+                    </button>
+                    <button
+                      :if={not is_nil(s.deleted_at)}
+                      type="button"
+                      role="menuitem"
+                      phx-click="restore_site"
+                      phx-value-id={s.id}
+                    >
+                      Restore
+                    </button>
+                  </div>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -488,7 +578,74 @@ defmodule MastheadWeb.AdminLive.Console do
           </form>
         </div>
       </div>
+      <div
+        :if={@gift_modal?}
+        class="dialog-backdrop"
+        phx-window-keydown="close_gift_modal"
+        phx-key="Escape"
+      >
+        <button
+          type="button"
+          phx-click="close_gift_modal"
+          class="dialog-close-overlay"
+          aria-label="Close"
+          tabindex="-1"
+        >
+        </button>
+        <div class="dialog">
+          <header class="dialog-header">
+            <h2>Gift Pro{if @gift_site, do: " — #{@gift_site.name}"}</h2>
+            <button type="button" phx-click="close_gift_modal" class="dialog-close" aria-label="Close">
+              &times;
+            </button>
+          </header>
+
+          <form phx-submit="gift_pro" class="dialog-form">
+            <label>
+              Months
+              <input
+                type="number"
+                name="months"
+                value="3"
+                min="1"
+                max="120"
+                step="1"
+                required
+                autocomplete="off"
+              />
+              <small>
+                {gift_hint(@gift_site)} No card is charged and no subscription is created.
+              </small>
+            </label>
+            <div class="dialog-footer">
+              <button type="button" phx-click="close_gift_modal" class="btn">Cancel</button>
+              <button type="submit" class="btn btn-primary">Gift Pro</button>
+            </div>
+          </form>
+        </div>
+      </div>
     </.shell>
+    """
+  end
+
+  defp gift_hint(nil), do: ""
+
+  defp gift_hint(site) do
+    if Licenses.paid?(site),
+      do: "Added on top of the current expiry (#{gift_date(site)}).",
+      else: "Starts today."
+  end
+
+  defp gift_date(%{license_expires_at: nil}), do: "—"
+  defp gift_date(%{license_expires_at: at}), do: Calendar.strftime(at, "%-d %B %Y")
+
+  defp dots_icon(assigns) do
+    ~H"""
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <circle cx="12" cy="5" r="1.75" />
+      <circle cx="12" cy="12" r="1.75" />
+      <circle cx="12" cy="19" r="1.75" />
+    </svg>
     """
   end
 end

--- a/lib/masthead_web/live/admin/site_settings.ex
+++ b/lib/masthead_web/live/admin/site_settings.ex
@@ -408,7 +408,7 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
                 </span>
 
                 <button
-                  :if={Licenses.paid?(@site)}
+                  :if={Licenses.paid?(@site) and Licenses.billable?(@site)}
                   type="button"
                   phx-click="billing_portal"
                   class="btn"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.25.0",
+      version: "2.25.1",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/masthead/licenses_test.exs
+++ b/test/masthead/licenses_test.exs
@@ -203,4 +203,59 @@ defmodule Masthead.LicensesTest do
                Sites.invite_to_site(site, "friend@example.com", fn t -> "u/#{t}" end)
     end
   end
+
+  describe "gift/2" do
+    test "licenses a free site from today", %{site: site} do
+      {:ok, site} = Licenses.gift(site, 3)
+
+      assert Licenses.paid?(site)
+      assert site.license_plan == "gift"
+      assert DateTime.diff(site.license_expires_at, DateTime.utc_now(), :day) in 89..92
+    end
+
+    test "adds onto an existing expiry rather than cutting it short", %{site: site} do
+      {:ok, paid} = Licenses.grant(site, "yearly", at(300))
+      {:ok, gifted} = Licenses.gift(paid, 2)
+
+      assert DateTime.after?(gifted.license_expires_at, paid.license_expires_at)
+      assert DateTime.diff(gifted.license_expires_at, paid.license_expires_at, :day) in 58..62
+    end
+
+    test "keeps the plan a paying site is already on", %{site: site} do
+      {:ok, paid} = Licenses.grant(site, "yearly", at(10))
+      {:ok, gifted} = Licenses.gift(paid, 1)
+
+      assert gifted.license_plan == "yearly"
+    end
+
+    test "restarts from today once a license has lapsed", %{site: site} do
+      {:ok, lapsed} = Licenses.grant(site, "monthly", at(-40))
+      {:ok, gifted} = Licenses.gift(lapsed, 1)
+
+      assert Licenses.paid?(gifted)
+      assert DateTime.after?(gifted.license_expires_at, DateTime.utc_now())
+    end
+  end
+
+  describe "admin paid/free filters" do
+    test "split the sites between them", %{site: site} do
+      paid = fn -> Enum.map(Sites.list_all_sites(:paid, nil, 50), & &1.slug) end
+      free = fn -> Enum.map(Sites.list_all_sites(:free, nil, 50), & &1.slug) end
+
+      assert site.slug in free.()
+      refute site.slug in paid.()
+
+      {:ok, _} = Licenses.gift(site, 1)
+
+      assert site.slug in paid.()
+      refute site.slug in free.()
+    end
+
+    test "an expired license counts as free", %{site: site} do
+      {:ok, _} = Licenses.grant(site, "yearly", at(-1))
+
+      assert site.slug in Enum.map(Sites.list_all_sites(:free, nil, 50), & &1.slug)
+      refute site.slug in Enum.map(Sites.list_all_sites(:paid, nil, 50), & &1.slug)
+    end
+  end
 end

--- a/test/masthead_web/admin_console_live_test.exs
+++ b/test/masthead_web/admin_console_live_test.exs
@@ -127,6 +127,8 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
     {:ok, lv, _} = live(conn, ~p"/admin")
     lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
 
+    open_row_menu(lv, site)
+
     lv
     |> element(~s(button[phx-click="disable_site"][phx-value-id="#{site.id}"]))
     |> render_click()
@@ -140,6 +142,8 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
     )
     |> render_click()
 
+    open_row_menu(lv, site)
+
     lv
     |> element(~s(button[phx-click="enable_site"][phx-value-id="#{site.id}"]))
     |> render_click()
@@ -150,6 +154,8 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
   test "admin can soft-delete and restore a site", %{conn: conn, site: site} do
     {:ok, lv, _} = live(conn, ~p"/admin")
     lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+
+    open_row_menu(lv, site)
 
     lv
     |> element(~s(button[phx-click="delete_site"][phx-value-id="#{site.id}"]))
@@ -164,6 +170,8 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
     )
     |> render_click()
 
+    open_row_menu(lv, site)
+
     lv
     |> element(~s(button[phx-click="restore_site"][phx-value-id="#{site.id}"]))
     |> render_click()
@@ -174,6 +182,8 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
   test "admin can add a custom action to a site via the modal", %{conn: conn, site: site} do
     {:ok, lv, _} = live(conn, ~p"/admin")
     lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+
+    open_row_menu(lv, site)
 
     lv
     |> element(~s(button[phx-click="open_action_modal"][phx-value-site_id="#{site.id}"]))
@@ -233,5 +243,46 @@ defmodule MastheadWeb.AdminConsoleLiveTest do
     result = Masthead.Themes.Package.install(tmp, owner_id)
     File.rm(tmp)
     result
+  end
+
+  defp open_row_menu(lv, site) do
+    lv
+    |> element(~s(button[phx-click="toggle_menu"][phx-value-id="#{site.id}"]))
+    |> render_click()
+  end
+
+  test "the row menu gifts Pro to a site", %{conn: conn, site: site} do
+    {:ok, lv, _} = live(conn, ~p"/admin")
+    lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+
+    refute Masthead.Licenses.paid?(Sites.get_site!(site.id))
+
+    open_row_menu(lv, site)
+
+    lv
+    |> element(~s(button[phx-click="open_gift_modal"][phx-value-site_id="#{site.id}"]))
+    |> render_click()
+
+    lv |> form(~s(form[phx-submit="gift_pro"]), %{months: "4"}) |> render_submit()
+
+    site = Sites.get_site!(site.id)
+    assert Masthead.Licenses.paid?(site)
+    assert site.license_plan == "gift"
+    assert DateTime.diff(site.license_expires_at, DateTime.utc_now(), :day) in 119..123
+  end
+
+  test "gifting rejects a nonsense number of months", %{conn: conn, site: site} do
+    {:ok, lv, _} = live(conn, ~p"/admin")
+    lv |> element(~s(button[phx-value-tab="sites"])) |> render_click()
+    open_row_menu(lv, site)
+
+    lv
+    |> element(~s(button[phx-click="open_gift_modal"][phx-value-site_id="#{site.id}"]))
+    |> render_click()
+
+    html = lv |> form(~s(form[phx-submit="gift_pro"]), %{months: "0"}) |> render_submit()
+
+    assert html =~ "between 1 and 120"
+    refute Masthead.Licenses.paid?(Sites.get_site!(site.id))
   end
 end

--- a/test/masthead_web/site_settings_live_test.exs
+++ b/test/masthead_web/site_settings_live_test.exs
@@ -203,7 +203,7 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
       conn: conn,
       site: site
     } do
-      {:ok, _site} = Masthead.Licenses.grant(site, "yearly")
+      {:ok, _site} = licensed_with_billing(site)
 
       {:ok, lv, html} = live(conn, ~p"/#{site.slug}/settings")
 
@@ -215,15 +215,28 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
     end
 
     test "a provider failure is reported instead of redirecting", %{conn: conn, site: site} do
-      {:ok, _site} = Masthead.Licenses.grant(site, "yearly")
+      Application.put_env(:masthead, :payments_stub, %{
+        checkout_url: {:error, "billing is not configured"}
+      })
+
       {:ok, lv, _html} = live(conn, ~p"/#{site.slug}/settings")
 
       html =
         lv
-        |> element(~s(button[phx-click="billing_portal"]))
+        |> element(~s(button[phx-click="checkout"][phx-value-plan="yearly"]))
         |> render_click()
 
-      assert html =~ "this site has no billing account yet"
+      assert html =~ "billing is not configured"
+    end
+
+    test "a gifted site is not offered the billing portal", %{conn: conn, site: site} do
+      {:ok, _site} = Masthead.Licenses.gift(site, 6)
+
+      {:ok, lv, html} = live(conn, ~p"/#{site.slug}/settings")
+
+      assert html =~ "Paid"
+      refute html =~ "Manage billing"
+      refute has_element?(lv, ~s(button[phx-click="billing_portal"]))
     end
 
     test "a webhook landing elsewhere flips the section live", %{conn: conn, site: site} do
@@ -267,5 +280,13 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
       refute html =~ "Upgrade this site to set up a custom domain."
       assert has_element?(lv, ~s(a[href="/#{site.slug}/domain"]), "Set up a custom domain")
     end
+  end
+
+  defp licensed_with_billing(site) do
+    {:ok, site} = Masthead.Licenses.grant(site, "yearly")
+
+    site
+    |> Ecto.Changeset.change(payment_customer_id: "cus_test", payment_subscription_id: "sub_test")
+    |> Masthead.Repo.update()
   end
 end


### PR DESCRIPTION
Per-row admin actions collapse behind one kebab menu — Enter, Add action, Gift Pro, Disable/Enable, Delete/Restore — which frees the column the "+ Action" button used to occupy.

Gift Pro licenses a site for a number of months with no provider subscription behind it. It adds onto an existing expiry rather than replacing it, so topping up a paying customer never cuts them short, and it counts calendar months. Because a gifted site has no provider customer, the billing portal button is now hidden unless one exists — otherwise it opened only to fail.

The sites table gains a License column and Paid/Free filters. The free filter spells out its NULL cases: `status IN (...)` yields NULL rather than false for an unlicensed site, so a plain NOT would have hidden every free site.

Two CSS fixes the menu forced: `.table` clipped its own overflow to round its corners, so the panel was cut off at the table edge — the corner radii now sit on the corner cells for tables that carry menus. And long site names on the overview ran underneath the status chip; they truncate before it now.

v2.25.1