### PR TITLE
fix: free a soft-deleted site's slug

### DIFF
--- a/lib/masthead/sites.ex
+++ b/lib/masthead/sites.ex
@@ -115,10 +115,6 @@ defmodule Masthead.Sites do
     Repo.one!(from s in Site, where: s.slug == ^slug and is_nil(s.deleted_at))
   end
 
-  defp set_site_timestamp(%Site{} = site, field, value) do
-    site |> Ecto.Changeset.change(%{field => value}) |> Repo.update()
-  end
-
   @doc """
   Pauses a site manually from the console (stops resolving). Tagged
   `disabled_reason: "admin"` so the member-availability cascade never
@@ -137,9 +133,15 @@ defmodule Masthead.Sites do
     |> Repo.update()
   end
 
-  @doc "Soft-deletes a site (hidden from owner + public; retained for recovery)."
+  @doc """
+  Soft-deletes a site (hidden from owner + public; retained for recovery).
+
+  The slug is suffixed on the way out so it stops occupying the name — a
+  deleted site would otherwise block anyone, its own owner included, from
+  reusing that address. `restore_site/1` takes the original back.
+  """
   def soft_delete_site(%Site{} = site) do
-    case set_site_timestamp(site, :deleted_at, truncated_now()) do
+    case archive_site(site) do
       {:ok, _} = result ->
         Realtime.site_gone(site.id)
         result
@@ -149,8 +151,41 @@ defmodule Masthead.Sites do
     end
   end
 
-  @doc "Restores a soft-deleted site."
-  def restore_site(%Site{} = site), do: set_site_timestamp(site, :deleted_at, nil)
+  @doc """
+  Restores a soft-deleted site, reclaiming the slug it had before deletion
+  when nobody has taken it in the meantime (otherwise it keeps the suffixed
+  one, which is at least free).
+  """
+  def restore_site(%Site{} = site) do
+    site
+    |> Ecto.Changeset.change(deleted_at: nil, slug: restored_slug(site))
+    |> Ecto.Changeset.unique_constraint(:slug)
+    |> Repo.update()
+  end
+
+  defp archive_site(site) do
+    site
+    |> Ecto.Changeset.change(deleted_at: truncated_now(), slug: archived_slug(site.slug))
+    |> Ecto.Changeset.unique_constraint(:slug)
+    |> Repo.update()
+  end
+
+  # "example" -> "example-deleted-9f3ac1b2": readable in the console, and the
+  # original is still in there for a restore to peel back off.
+  defp archived_slug(slug), do: "#{slug}-deleted-#{random_suffix()}"
+
+  defp random_suffix, do: 4 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  defp restored_slug(%Site{slug: slug} = site) do
+    case String.replace(slug, ~r/-deleted-[0-9a-f]{8}$/, "") do
+      ^slug -> slug
+      original -> free_slug(original, slug, site.id)
+    end
+  end
+
+  defp free_slug(original, fallback, site_id) do
+    if slug_taken?(original, site_id), do: fallback, else: original
+  end
 
   defp truncated_now, do: DateTime.utc_now() |> DateTime.truncate(:second)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.25.2",
+      version: "2.25.3",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260907140605_free_slugs_of_deleted_sites.exs
+++ b/priv/repo/migrations/20260907140605_free_slugs_of_deleted_sites.exs
@@ -1,0 +1,18 @@
+defmodule Masthead.Repo.Migrations.FreeSlugsOfDeletedSites do
+  use Ecto.Migration
+
+  # Sites deleted before the rename-on-delete change still hold their slug
+  # hostage. Suffix them the same way, so those names come free.
+  def up do
+    execute("""
+    UPDATE sites
+       SET slug = slug || '-deleted-' || substr(md5(random()::text), 1, 8)
+     WHERE deleted_at IS NOT NULL
+       AND slug !~ '-deleted-[0-9a-f]{8}$'
+    """)
+  end
+
+  # The original slug is recoverable from the suffixed one (that's what
+  # restoring a site does), so there is nothing to undo here.
+  def down, do: :ok
+end

--- a/test/masthead/sites_soft_delete_test.exs
+++ b/test/masthead/sites_soft_delete_test.exs
@@ -34,6 +34,32 @@ defmodule Masthead.SitesSoftDeleteTest do
     assert Sites.get_site_by_slug(site.slug)
   end
 
+  test "deleting frees the slug for a new site", %{user: user, site: site} do
+    {:ok, deleted} = Sites.soft_delete_site(site)
+
+    assert deleted.slug =~ ~r/^#{site.slug}-deleted-[0-9a-f]{8}$/
+
+    assert {:ok, replacement} =
+             Sites.create_site(%{"slug" => site.slug, "name" => "Reuse", "owner_id" => user.id})
+
+    assert replacement.slug == site.slug
+  end
+
+  test "restoring keeps the suffixed slug when the original was taken", %{
+    user: user,
+    site: site
+  } do
+    {:ok, deleted} = Sites.soft_delete_site(site)
+
+    {:ok, _} =
+      Sites.create_site(%{"slug" => site.slug, "name" => "Reuse", "owner_id" => user.id})
+
+    {:ok, restored} = Sites.restore_site(Sites.get_site!(deleted.id))
+
+    assert restored.slug == deleted.slug
+    assert Sites.get_site_by_slug(restored.slug).id == site.id
+  end
+
   test "a disabled site stays visible to its owner but stops resolving", %{user: user, site: site} do
     {:ok, _} = Sites.disable_site(site)
 


### PR DESCRIPTION
A soft-deleted site kept its slug, so the name stayed blocked for everyone, its own owner included. Deleting now suffixes the slug (example -> example-deleted-9f3ac1b2) and restoring peels the suffix back off when nobody claimed the original meanwhile. A migration does the same to sites deleted before this change.

Version 2.25.3.