### PR TITLE
feat: let an owner take their site offline

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -355,6 +355,12 @@ code { font-family: ui-monospace, Menlo, monospace; font-size: 0.9em; background
   background: rgba(22, 101, 52, 0.22);
 }
 
+.sidebar-pill-offline {
+  color: #fca5a5;
+  border-color: #7f1d1d;
+  background: rgba(127, 29, 29, 0.28);
+}
+
 .sidebar-version {
   margin: 0.25rem 0 0;
   font-size: 0.72rem;

--- a/lib/masthead/sites.ex
+++ b/lib/masthead/sites.ex
@@ -120,13 +120,24 @@ defmodule Masthead.Sites do
   `disabled_reason: "admin"` so the member-availability cascade never
   re-enables it. Reversible via `enable_site/1`.
   """
-  def disable_site(%Site{} = site) do
+  def disable_site(%Site{} = site, reason \\ "admin") do
     site
-    |> Ecto.Changeset.change(disabled_at: truncated_now(), disabled_reason: "admin")
+    |> Ecto.Changeset.change(disabled_at: truncated_now(), disabled_reason: reason)
     |> Repo.update()
   end
 
-  @doc "Un-pauses a site (admin)."
+  @doc """
+  The owner taking their own site down. Tagged `disabled_reason: "owner"`
+  so nothing else brings it back — not the member-availability cascade, and
+  not an admin un-pause looking at its own work.
+  """
+  def take_offline(%Site{} = site), do: disable_site(site, "owner")
+
+  @doc "True when the site is offline because its owner took it down."
+  def taken_offline?(%Site{disabled_reason: "owner", disabled_at: at}), do: not is_nil(at)
+  def taken_offline?(%Site{}), do: false
+
+  @doc "Un-pauses a site (admin, or the owner undoing their own take-down)."
   def enable_site(%Site{} = site) do
     site
     |> Ecto.Changeset.change(disabled_at: nil, disabled_reason: nil)

--- a/lib/masthead_web/live/admin/components.ex
+++ b/lib/masthead_web/live/admin/components.ex
@@ -77,8 +77,8 @@ defmodule MastheadWeb.AdminLive.Components do
           <p class="sidebar-version">v{Application.spec(:masthead, :vsn)}</p>
           <p :if={@site} class="sidebar-site">
             <span class="sidebar-site-name">{@site.name}</span>
-            <span class={["sidebar-pill", Masthead.Licenses.paid?(@site) && "sidebar-pill-paid"]}>
-              {Masthead.Licenses.label(@site)}
+            <span class={["sidebar-pill", sidebar_pill_class(@site)]}>
+              {site_chip_label(@site)}
             </span>
           </p>
         </div>
@@ -885,6 +885,23 @@ defmodule MastheadWeb.AdminLive.Components do
     </div>
     """
   end
+
+  @doc """
+  What a site's chip says: its license, unless the site is offline — an
+  owner who took their site down cares about that before the plan.
+  """
+  def site_chip_label(%{disabled_at: nil} = site), do: Masthead.Licenses.label(site)
+  def site_chip_label(_site), do: "Offline"
+
+  @doc "Pill class matching `site_chip_label/1`."
+  def site_chip_class(%{disabled_at: nil} = site), do: Masthead.Licenses.pill_class(site)
+  def site_chip_class(_site), do: "pill-danger"
+
+  defp sidebar_pill_class(%{disabled_at: nil} = site) do
+    Masthead.Licenses.paid?(site) && "sidebar-pill-paid"
+  end
+
+  defp sidebar_pill_class(_site), do: "sidebar-pill-offline"
 
   @doc false
   # Builds the public URL for a site based on `:masthead, :site_url`:

--- a/lib/masthead_web/live/admin/site_index.ex
+++ b/lib/masthead_web/live/admin/site_index.ex
@@ -1,7 +1,6 @@
 defmodule MastheadWeb.AdminLive.SiteIndex do
   use MastheadWeb, :live_view
   import MastheadWeb.AdminLive.Components
-  alias Masthead.Licenses
   alias Masthead.Sites
   alias Masthead.Sites.Site
 
@@ -117,7 +116,7 @@ defmodule MastheadWeb.AdminLive.SiteIndex do
 
       <ul :if={@sites != []} class="card-list">
         <li :for={s <- @sites}>
-          <span class={"pill card-pill " <> Licenses.pill_class(s)}>{Licenses.label(s)}</span>
+          <span class={"pill card-pill " <> site_chip_class(s)}>{site_chip_label(s)}</span>
           <.link navigate={~p"/#{s.slug}"}>
             <strong>{s.name}</strong>
             <span class="muted">{s.slug}.{@host}</span>

--- a/lib/masthead_web/live/admin/site_settings.ex
+++ b/lib/masthead_web/live/admin/site_settings.ex
@@ -98,6 +98,24 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
     end
   end
 
+  def handle_event("take_offline", _params, socket) do
+    {:ok, site} = Sites.take_offline(socket.assigns.site)
+
+    {:noreply,
+     socket
+     |> assign(site: site)
+     |> put_flash(:info, "#{site.name} is offline. Visitors now get a not-found page.")}
+  end
+
+  def handle_event("bring_online", _params, socket) do
+    {:ok, site} = Sites.enable_site(socket.assigns.site)
+
+    {:noreply,
+     socket
+     |> assign(site: site)
+     |> put_flash(:info, "#{site.name} is back online.")}
+  end
+
   def handle_event("delete_site", _params, socket) do
     # The site is owner-scoped by the :load_site hook, so the current user is
     # authorized. Soft-delete keeps the row recoverable (by an admin); the
@@ -489,6 +507,43 @@ defmodule MastheadWeb.AdminLive.SiteSettings do
             </header>
 
             <div class="settings-fields">
+              <div class="danger-row">
+                <div>
+                  <strong>
+                    {if Sites.taken_offline?(@site), do: "Bring back online", else: "Take offline"}
+                  </strong>
+                  <p class="muted">
+                    <span :if={Sites.taken_offline?(@site)}>
+                      This site is offline — visitors get a not-found page. Your content is
+                      untouched and comes straight back.
+                    </span>
+                    <span :if={not Sites.taken_offline?(@site) and is_nil(@site.disabled_at)}>
+                      Stops <code>{@site.slug}.{@host}</code> from resolving without deleting
+                      anything. You can bring it back whenever you like.
+                    </span>
+                    <span :if={not Sites.taken_offline?(@site) and not is_nil(@site.disabled_at)}>
+                      This site was taken offline by an admin — contact support to bring it back.
+                    </span>
+                  </p>
+                </div>
+                <button
+                  :if={Sites.taken_offline?(@site)}
+                  type="button"
+                  phx-click="bring_online"
+                  class="btn"
+                >
+                  Bring online
+                </button>
+                <button
+                  :if={is_nil(@site.disabled_at)}
+                  type="button"
+                  phx-click="take_offline"
+                  class="btn btn-danger"
+                  data-confirm={"Take #{@site.name} offline? Visitors will get a not-found page until you bring it back."}
+                >
+                  Take offline
+                </button>
+              </div>
               <div class="danger-row">
                 <div>
                   <strong>Change site address</strong>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Masthead.MixProject do
   def project do
     [
       app: :masthead,
-      version: "2.25.3",
+      version: "2.25.4",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/masthead_web/site_settings_live_test.exs
+++ b/test/masthead_web/site_settings_live_test.exs
@@ -32,6 +32,41 @@ defmodule MastheadWeb.SiteSettingsLiveTest do
     %{conn: conn, site: site, user: user}
   end
 
+  describe "taking the site offline" do
+    test "the owner can take the site down and bring it back", %{conn: conn, site: site} do
+      {:ok, lv, _} = live(conn, ~p"/#{site.slug}/settings")
+
+      html = lv |> element(~s(button[phx-click="take_offline"])) |> render_click()
+
+      assert html =~ "Bring online"
+      refute Sites.get_site_by_slug(site.slug)
+      assert Sites.taken_offline?(Sites.get_site!(site.id))
+
+      html = lv |> element(~s(button[phx-click="bring_online"])) |> render_click()
+
+      assert html =~ "Take offline"
+      assert Sites.get_site_by_slug(site.slug)
+    end
+
+    test "an offline site's card says so instead of its plan", %{conn: conn, site: site} do
+      {:ok, _} = Sites.take_offline(site)
+
+      {:ok, _lv, html} = live(conn, ~p"/sites")
+
+      assert html =~ "Offline"
+      refute html =~ ~s(card-pill pill-draft)
+    end
+
+    test "an admin pause is not the owner's to undo", %{conn: conn, site: site} do
+      {:ok, _} = Sites.disable_site(site)
+
+      {:ok, lv, html} = live(conn, ~p"/#{site.slug}/settings")
+
+      assert html =~ "taken offline by an admin"
+      assert lv |> element(~s(button[phx-click="bring_online"])) |> has_element?() == false
+    end
+  end
+
   describe "changing the site address" do
     test "the modal reports a free slug, a taken one, and a reserved one", %{
       conn: conn,


### PR DESCRIPTION
Adds a Take offline / Bring online row to the settings danger zone. The site stops resolving without losing anything, and the Free/Paid chip on the site card and in the sidebar says "Offline" while it is down.

The take-down is tagged `disabled_reason: "owner"` so nothing else undoes it, and so a site an admin paused stays out of the owner's hands — that row explains itself instead of offering a button.

Version 2.25.4.